### PR TITLE
chore: version patch 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pyroscope/nodejs",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pyroscope/nodejs",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyroscope/nodejs",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "pyroscope nodejs package",
   "exports": {
     ".": {


### PR DESCRIPTION
Our CI does not do version patch. Tag v0.2.7 already exists, therefore we update straight to v0.2.8