### PR TITLE
Add option to collectCpuTime for wall profiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pyroscope/nodejs",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pyroscope/nodejs",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@datadog/pprof": "^5.3.0",
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@commitlint/cli": "^18",
         "@commitlint/config-conventional": "^18",
+        "@types/busboy": "^1.5.4",
         "@types/debug": "^4.1.7",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.1",
@@ -26,6 +27,7 @@
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
+        "busboy": "^1.6.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -1657,6 +1659,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/busboy": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2867,6 +2878,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -7806,6 +7829,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10189,6 +10221,15 @@
         "@types/node": "*"
       }
     },
+    "@types/busboy": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -11101,6 +11142,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -14560,6 +14610,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "dev": true
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@commitlint/cli": "^18",
     "@commitlint/config-conventional": "^18",
+    "@types/busboy": "^1.5.4",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.1",
@@ -58,6 +59,7 @@
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
+    "busboy": "^1.6.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/src/profilers/pyroscope-profiler.ts
+++ b/src/profilers/pyroscope-profiler.ts
@@ -99,6 +99,7 @@ export class PyroscopeProfiler {
         samplingIntervalMicros:
           config.wall?.samplingIntervalMicros ??
           DEFAULT_SAMPLING_INTERVAL_MICROS,
+        collectCpuTime: config.wall?.collectCpuTime ?? false,
       },
     })
   }

--- a/src/profilers/wall-profiler.ts
+++ b/src/profilers/wall-profiler.ts
@@ -13,6 +13,7 @@ export interface WallProfilerStartArgs {
   samplingDurationMs: number
   samplingIntervalMicros: number
   sourceMapper: SourceMapper | undefined
+  collectCpuTime: boolean
 }
 
 export class WallProfiler implements Profiler<WallProfilerStartArgs> {
@@ -50,6 +51,7 @@ export class WallProfiler implements Profiler<WallProfilerStartArgs> {
         intervalMicros: args.samplingIntervalMicros,
         withContexts: true,
         workaroundV8Bug: true,
+        collectCpuTime: args.collectCpuTime,
       })
       time.setContext({})
     }

--- a/src/pyroscope-config.ts
+++ b/src/pyroscope-config.ts
@@ -17,6 +17,7 @@ export interface PyroscopeConfig {
 export interface PyroscopeWallConfig {
   samplingDurationMs?: number | undefined
   samplingIntervalMicros?: number | undefined
+  collectCpuTime?: boolean | undefined
 }
 
 export interface PyroscopeHeapConfig {

--- a/src/utils/process-config.ts
+++ b/src/utils/process-config.ts
@@ -22,6 +22,7 @@ export function processConfig(
         config.wall?.samplingDurationMs ?? env.wallSamplingDurationMs,
       samplingIntervalMicros:
         config.wall?.samplingIntervalMicros ?? env.wallSamplingIntervalMicros,
+      collectCpuTime: config.wall?.collectCpuTime ?? false,
     },
     sourceMapper: config.sourceMapper,
     basicAuthUser: config.basicAuthUser,

--- a/test/profiler.test.ts
+++ b/test/profiler.test.ts
@@ -1,5 +1,28 @@
 import Pyroscope from '../src'
 import express from 'express'
+import busboy from 'busboy'
+import { Profile } from 'pprof-format'
+import zlib from 'zlib'
+
+const extractProfile = (
+  req: express.Request,
+  res: express.Response,
+  callback: (p: Profile, name: String) => void
+) => {
+  const bb = busboy({ headers: req.headers })
+  bb.on('file', (name, file) => {
+    file
+      .toArray()
+      .then((values) => callback(
+        Profile.decode(zlib.gunzipSync(values[0])),
+        name,
+      ))
+  })
+  bb.on('close', () => {
+    res.send('ok')
+  })
+  req.pipe(bb)
+}
 
 describe('common behaviour of profilers', () => {
   it('should call a server on startCpuProfiling and clear gracefully', (done) => {
@@ -119,9 +142,9 @@ describe('common behaviour of profilers', () => {
     })()
   })
 
-  it('should have labels on cpu profile', (done) => {
+  it('should have labels on wall profile', (done) => {
     Pyroscope.init({
-      serverAddress: 'http://localhost:4445',
+      serverAddress: 'http://localhost:4446',
       appName: 'nodejs',
       flushIntervalMs: 100,
       heap: {
@@ -129,13 +152,14 @@ describe('common behaviour of profilers', () => {
       },
       wall: {
         samplingDurationMs: 1000,
+        samplingIntervalMicros: 100,
       },
     })
     Pyroscope.setWallLabels({
       vehicle: 'car',
     })
     const app = express()
-    const server = app.listen(4445, () => {
+    const server = app.listen(4446, () => {
       Pyroscope.startWallProfiling()
     })
 
@@ -144,7 +168,66 @@ describe('common behaviour of profilers', () => {
     app.post('/ingest', (req, res) => {
       expect(req.query['spyName']).toEqual('nodespy')
       expect(req.query['name']).toEqual('nodejs{}')
-      res.send('ok')
+      extractProfile(req, res, (p: Profile) => {
+        const s = (idx: Number | bigint) => p.stringTable.strings[Number(idx)]
+        // now take the first sample and check if it has the label as expected
+        expect(s(p.sample[0].label[0].key)).toEqual('vehicle')
+        expect(s(p.sample[0].label[0].str)).toEqual('car')
+
+        // expect sample, wall types
+        expect(p.sampleType.map((x) => `${s(x.type)}=${s(x.unit)}`)).toEqual([
+          'samples=count',
+          'wall=nanoseconds',
+        ])
+      })
+
+      if (!closeInvoked) {
+        closeInvoked = true
+        ;(async () => {
+          await Pyroscope.stopWallProfiling()
+          server.close(() => {
+            done()
+          })
+        })()
+      }
+    })
+  })
+
+  it('should have extra samples for cpu time when enabled on wall profile', (done) => {
+    Pyroscope.init({
+      serverAddress: 'http://localhost:4447',
+      appName: 'nodejs',
+      flushIntervalMs: 100,
+      heap: {
+        samplingIntervalBytes: 1000,
+      },
+      wall: {
+        samplingDurationMs: 1000,
+        samplingIntervalMicros: 100,
+        collectCpuTime: true,
+      },
+    })
+    const app = express()
+    const server = app.listen(4447, () => {
+      Pyroscope.startWallProfiling()
+    })
+
+    let closeInvoked = false
+
+    app.post('/ingest', (req, res) => {
+      expect(req.query['spyName']).toEqual('nodespy')
+      expect(req.query['name']).toEqual('nodejs{}')
+
+      extractProfile(req, res, (p: Profile) => {
+        const s = (idx: Number | bigint) => p.stringTable.strings[Number(idx)]
+        // expect sample, wall and cpu types
+        expect(p.sampleType.map((x) => `${s(x.type)}=${s(x.unit)}`)).toEqual([
+          'samples=count',
+          'wall=nanoseconds',
+          'cpu=nanoseconds',
+        ])
+      })
+
       if (!closeInvoked) {
         closeInvoked = true
         ;(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/busboy@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz"
+  integrity sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/connect@*":
   version "3.4.38"
   resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz"
@@ -1566,6 +1573,13 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -4413,6 +4427,11 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 string_decoder@^1.1.1:
   version "1.3.0"


### PR DESCRIPTION
This is currently disabled by default, to gather feedback.

This also adds decoding of pprof into the test cases to look slightly deeper into the generated data.

