### PR TITLE
Restore fileName to anonymous function names

### DIFF
--- a/src/utils/process-profile.ts
+++ b/src/utils/process-profile.ts
@@ -25,7 +25,10 @@ function adjustCwdPaths(profile: Profile): void {
         const functionName: string | undefined =
           profile.stringTable.strings[Number(contextFunction.name)]
 
-        if (!(functionName?.includes(':') ?? false)) {
+        if (
+          !functionName?.includes(':') ||
+          functionName?.startsWith('(anonymous')
+        ) {
           const fileName: string = profile.stringTable.strings[
             Number(contextFunction.filename)
           ] as string


### PR DESCRIPTION
Anonymous functions used to be named just `(anonymous)`, but as of DataDog/pprof-nodejs#141 they are named things like `(anonymous:L#42:C#16)` which triggers the `:` detection here. That logic dates from commit dcca5749da3f82706500403f9a52493e120fa809 which predates the anonymous function name change, and so pretty clearly wasn't intended to cover it.

This change means that instead of anonymous functions being reported in pyroscope as just `(anonymous:L#42:C#16)`, they are instead reported as `./dist/example.js:(anonymous:L#42:C#16):42` which is a lot more pleasant to work with.