### PR TITLE
Fix `SourceMapper` typing

### DIFF
--- a/src/profilers/pyroscope-profiler.ts
+++ b/src/profilers/pyroscope-profiler.ts
@@ -1,8 +1,11 @@
+import { SourceMapper as DDSourceMapper } from '@datadog/pprof';
+
 import { PyroscopeApiExporter } from '../pyroscope-api-exporter.js';
-import { ContinuousProfiler } from './continuous-profiler.js';
-import { WallProfiler, WallProfilerStartArgs } from './wall-profiler.js';
-import { HeapProfiler, HeapProfilerStartArgs } from './heap-profiler.js';
 import { PyroscopeConfig } from '../pyroscope-config.js';
+import { SourceMapper } from '../sourcemapper.js';
+import { ContinuousProfiler } from './continuous-profiler.js';
+import { HeapProfiler, HeapProfilerStartArgs } from './heap-profiler.js';
+import { WallProfiler, WallProfilerStartArgs } from './wall-profiler.js';
 
 const MICROS_PER_SECOND = 1e6;
 const MS_PER_SECOND = 1e3;
@@ -76,7 +79,7 @@ export class PyroscopeProfiler {
       flushIntervalMs: flushIntervalMs,
       profiler: new HeapProfiler(),
       startArgs: {
-        sourceMapper: config.sourceMapper,
+        sourceMapper: this.toDDSourceMapper(config.sourceMapper),
         samplingIntervalBytes:
           config.heap?.samplingIntervalBytes ?? DEFAULT_SAMPLING_INTERVAL_BYTES,
         stackDepth: config.heap?.stackDepth ?? DEFAULT_STACK_DEPTH,
@@ -95,7 +98,7 @@ export class PyroscopeProfiler {
       flushIntervalMs: flushIntervalMs,
       profiler: new WallProfiler(),
       startArgs: {
-        sourceMapper: config.sourceMapper,
+        sourceMapper: this.toDDSourceMapper(config.sourceMapper),
         samplingDurationMs:
           config.wall?.samplingDurationMs ?? DEFAULT_SAMPLING_DURATION_MS,
         samplingIntervalMicros:
@@ -104,5 +107,27 @@ export class PyroscopeProfiler {
         collectCpuTime: config.wall?.collectCpuTime ?? false,
       },
     });
+  }
+
+  /**
+   * Converts a (Pyroscope) `SourceMapper` to a (DataDog) `SourceMapper`. These
+   * two types have the same shape, but since the DataDog SourceMapper has a
+   * private field `getMappingInfo`, we cannot use these two classes
+   * interchangeably.
+   *
+   * For a more detailed explanation as to why the private method makes the
+   * typical TypeScript type conversion impossible, see:
+   *
+   * https://github.com/microsoft/TypeScript/issues/7755#issuecomment-204161372
+   *
+   * @param sourceMapper A Pyroscope `SourceMapper`.
+   * @return A DataDog `SourceMapper`.
+   */
+  private toDDSourceMapper(sourceMapper: SourceMapper | undefined): DDSourceMapper | undefined {
+    if (!sourceMapper) {
+      return undefined;
+    }
+
+    return sourceMapper as unknown as DDSourceMapper;
   }
 }

--- a/src/pyroscope-config.ts
+++ b/src/pyroscope-config.ts
@@ -1,4 +1,6 @@
-import { SourceMapper, LabelSet } from '@datadog/pprof';
+import { LabelSet } from '@datadog/pprof';
+import { SourceMapper } from './sourcemapper.js';
+
 export { LabelSet } from '@datadog/pprof';
 
 export interface PyroscopeConfig {

--- a/src/sourcemapper.ts
+++ b/src/sourcemapper.ts
@@ -180,6 +180,7 @@ export class SourceMapper {
         `Looking for source map files in dirs: [${searchDirs.join(', ')}]`
       );
     }
+
     const mapFiles: string[] = [];
     for (const dir of searchDirs) {
       try {
@@ -190,6 +191,7 @@ export class SourceMapper {
       } catch (e) {
         throw error(`failed to get source maps from ${dir}: ${e}`);
       }
+
       try {
         const sf = await getSourceCodeFiles(dir);
         sf.forEach((sourceCodeFile) => {
@@ -199,9 +201,11 @@ export class SourceMapper {
         throw error(`failed to get source maps from ${dir}: ${e}`);
       }
     }
+
     if (debug) {
       logger.debug(`Found source map files: [${mapFiles.join(', ')}]`);
     }
+
     return createFromMapFiles(mapFiles, debug);
   }
 


### PR DESCRIPTION
When using the `SourceMapper` in a TypeScript project, the following error occurs:

```
Type 'import("/Users/bryan/grafana/pyroscope-nodejs/dist/cjs/sourcemapper").SourceMapper' is not assignable to type 'import("/Users/bryan/grafana/pyroscope-nodejs/node_modules/@datadog/pprof/out/src/sourcemapper/sourcemapper").SourceMapper'.
  Types have separate declarations of a private property 'getMappingInfo'.ts(2322)
```

The critical piece being:

```
Types have separate declarations of a private property 'getMappingInfo'.ts(2322)
```

This comes from this method:

https://github.com/grafana/pyroscope-nodejs/blob/4c286e74139c5b68338c7c19ac6226af006bef36/src/sourcemapper.ts#L232-L237

The cause is that we can't use the `@pyroscope/nodejs` `SourceMapper` type in place of the `@ddog/pprof` `SourceMapper` type because private methods aren't considered when matching type shapes in TypeScript. See https://github.com/microsoft/TypeScript/issues/7755#issuecomment-204161372 for an example and explanation.

As a result, we should not expose the `@ddog/pprof` `SourceMapper` type in the `PyroscopeConfig` type. Rather, we should expose our own implementation of `SourceMapper` then do a conversion to the DataDog type internally.