### PR TITLE
chore: Update `@datadog/pprof` to v5.4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 23.x
       - name: Install modules
         run: yarn
       - name: Lint code base
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node: [18.x, 20.x, 21.x, 22.x]
+        node: [18.x, 20.x, 21.x, 22.x, 23.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/grafana/pyroscope-nodejs/issues"
   },
   "dependencies": {
-    "@datadog/pprof": "^5.3.0",
+    "@datadog/pprof": "^5.4.1",
     "axios": "^0.28.0",
     "debug": "^4.3.3",
     "form-data": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/pprof@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz"
-  integrity sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==
+"@datadog/pprof@^5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.4.1.tgz#08c9bcf5d8efb2eeafdfc9f5bb5402f79fb41266"
+  integrity sha512-IvpL96e/cuh8ugP5O8Czdup7XQOLHeIDgM5pac5W7Lc1YzGe5zTtebKFpitvb1CPw1YY+1qFx0pWGgKP2kOfHg==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
This updated the upstream dependecy to support latest nodejs v23