### PR TITLE
Exception as optional chaining is used through the whole chain

### DIFF
--- a/src/profilers/wall-profiler.ts
+++ b/src/profilers/wall-profiler.ts
@@ -104,7 +104,7 @@ export class WallProfiler implements Profiler<WallProfilerStartArgs> {
   }
 
   private generateLabels(args: GenerateTimeLabelsArgs): LabelSet {
-    return { ...(args.context?.context.labels ?? {}) };
+    return { ...(args.context?.context?.labels ?? {}) };
   }
 
   private innerProfile(restart: boolean): ProfileExport {


### PR DESCRIPTION
# What this PR does
This PR fixes an issue where the code used partial optional chaining:

```js
args.context?.context.labels
```

While this prevents an exception on args.context?.context - if it is undefined this immediately then throws an exception as .labels is trying to be accessed on an undefined.

The change applies full optional chaining:

```js
args.context?.context?.labels
```

This ensures that if either args.context or args.context.context is undefined or null, the expression safely returns undefined instead of throwing an exception.

# Why this is needed
In some scenarios, the context object may not be fully populated, and attempting to access labels without proper checks could cause runtime errors. This change makes the property access safe and prevents unexpected crashes.

This occurred after an upgrade to the latest Pyroscope, which seems to update the datadog libraries that call this line.

```
TypeError: Cannot read properties of undefined (reading 'labels')
    at generateLabels (/usr/src/app/node_modules/@pyroscope/nodejs/dist/cjs/profilers/wall-profiler.js:67:43)
    at appendTimeEntryToSamples (/usr/src/app/node_modules/@datadog/pprof/out/src/profile-serializer.js:290:19)
    at serialize (/usr/src/app/node_modules/@datadog/pprof/out/src/profile-serializer.js:62:9)
    at serializeTimeProfile (/usr/src/app/node_modules/@datadog/pprof/out/src/profile-serializer.js:344:5)
    at Object.stop (/usr/src/app/node_modules/@datadog/pprof/out/src/time-profiler.js:91:78)
    at WallProfiler.innerProfile (/usr/src/app/node_modules/@pyroscope/nodejs/dist/cjs/profilers/wall-profiler.js:71:38)
    at WallProfiler.profile (/usr/src/app/node_modules/@pyroscope/nodejs/dist/cjs/profilers/wall-profiler.js:24:21)
    at ContinuousProfiler.profilingRound (/usr/src/app/node_modules/@pyroscope/nodejs/dist/cjs/profilers/continuous-profiler.js:62:45)
    at Immediate.<anonymous> (/usr/src/app/node_modules/@pyroscope/nodejs/dist/cjs/profilers/continuous-profiler.js:56:27)
    at process.processImmediate (node:internal/timers:508:21)
```
