### PR TITLE
fix: Basic auth (was broken in v0.4.4) and test were not running

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
 import 'regenerator-runtime/runtime.js';
 
+import { setLogger as datadogSetLogger } from '@datadog/pprof';
 import expressMiddleware from './express/middleware.js';
+import { Logger, setLogger as ourSetLogger } from './logger.js';
 import { PyroscopeProfiler } from './profilers/pyroscope-profiler.js';
 import {
   PyroscopeConfig,
   PyroscopeHeapConfig,
   PyroscopeWallConfig,
 } from './pyroscope-config.js';
-import { checkPyroscopeConfig } from './utils/check-pyroscope-config.js';
-import { getProfiler, setProfiler } from './utils/pyroscope-profiler.js';
-import { processConfig } from './utils/process-config.js';
-import { getEnv } from './utils/get-env.js';
-import { setLogger as datadogSetLogger } from '@datadog/pprof';
-import { setLogger as ourSetLogger, Logger } from './logger.js';
 import { SourceMapper } from './sourcemapper.js';
+import { checkPyroscopeConfig } from './utils/check-pyroscope-config.js';
+import { getEnv } from './utils/get-env.js';
+import { processConfig } from './utils/process-config.js';
+import { getProfiler, setProfiler } from './utils/pyroscope-profiler.js';
 
 export function init(config: PyroscopeConfig = {}): void {
   checkPyroscopeConfig(config);

--- a/src/pyroscope-api-exporter.ts
+++ b/src/pyroscope-api-exporter.ts
@@ -64,9 +64,9 @@ export class PyroscopeApiExporter implements ProfileExporter {
     } else if (this.config.basicAuthUser && this.config.basicAuthPassword) {
       headers.set(
         'authorization',
-        Buffer.from(
+        `Basic ${Buffer.from(
           `${this.config.basicAuthUser}:${this.config.basicAuthPassword}`
-        ).toString('base64')
+        ).toString('base64')}`
       );
     }
 

--- a/test/profiler.test.ts
+++ b/test/profiler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, onTestFinished } from 'vitest';
 
 import Pyroscope from '../src/index.js';
 import express from 'express';
@@ -6,7 +6,7 @@ import busboy from 'busboy';
 import { Profile } from 'pprof-format';
 import zlib from 'zlib';
 
-// createBackend creates an Express server with an /ingest endpoint and returns a promise 
+// createBackend creates an Express server with an /ingest endpoint and returns a promise
 // that resolves to the HTTP port the server is listening on
 const createBackend = (handler: express.RequestHandler): Promise<number> => {
   const server = express();
@@ -18,6 +18,9 @@ const createBackend = (handler: express.RequestHandler): Promise<number> => {
       } else {
         rejectPort('Could not resolve port');
       }
+    });
+    onTestFinished(() => {
+      httpServer.close();
     });
   });
   server.post('/ingest', handler);

--- a/test/profiler.test.ts
+++ b/test/profiler.test.ts
@@ -6,6 +6,18 @@ import busboy from 'busboy';
 import { Profile } from 'pprof-format';
 import zlib from 'zlib';
 
+// create a backend returns two promises: the http port it is listening on and the first call it receives
+const createBackend = (handler): Promise<number> => {
+  const server = express();
+  const port = new Promise<number>((resolvePort) => {
+    const httpServer = server.listen(0, () => {
+      resolvePort(httpServer.address().port);
+    });
+  });
+  server.post('/ingest', handler);
+  return port;
+};
+
 type Numeric = number | bigint;
 
 const extractProfile = (
@@ -36,84 +48,76 @@ const doWork = (d: number): void => {
 };
 
 describe('common behaviour of profilers', () => {
-  it('should call a server on startCpuProfiling and clear gracefully', (done) => {
-    Pyroscope.init({
-      serverAddress: 'http://localhost:4445',
-      appName: 'nodejs',
-      flushIntervalMs: 100,
-      wall: {
-        samplingDurationMs: 1000,
-      },
-    });
-    const app = express();
-    const server = app.listen(4445, () => {
-      Pyroscope.startWallProfiling();
+  it('should call a server on startCpuProfiling and clear gracefully', async () => {
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          resolve(req);
+          res.send('ok');
+        }
+      );
+
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          wall: {
+            samplingDurationMs: 1000,
+          },
+        });
+        Pyroscope.startWallProfiling();
+        doWork(0.1);
+      });
     });
 
-    let closeInvoked = false;
-
-    app.post('/ingest', (req, res) => {
-      expect(req.query['spyName']).toEqual('nodespy');
-      expect(req.query['name']).toEqual('nodejs{}');
-      res.send('ok');
-      if (!closeInvoked) {
-        closeInvoked = true;
-        (async () => {
-          await Pyroscope.stopWallProfiling();
-          server.close(() => {
-            done();
-          });
-        })();
-      }
-    });
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+    expect(req.query.spyName).toBe('nodespy');
+    expect(req.query.name).toBe('nodejs{}');
   });
 
-  it('should call a server on startHeapProfiling and clear gracefully', (done) => {
-    // Simulate memory usage
-    const timer: NodeJS.Timeout = setInterval(() => {
-      // Use some memory
-      new Array<number>(2000)
-        .fill(3)
-        .reduce(
-          (previous: number, current: number): number => previous + current,
-          0
-        );
-    }, 100);
+  it('should call a server on startHeapProfiling and clear gracefully', async () => {
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          resolve(req);
+          res.send('ok');
+        }
+      );
 
-    Pyroscope.init({
-      serverAddress: 'http://localhost:4444',
-      appName: 'nodejs',
-      flushIntervalMs: 100,
-      tags: { env: 'test env' },
-      heap: {
-        samplingIntervalBytes: 1024,
-      },
-      wall: {
-        samplingDurationMs: 1000,
-      },
-    });
-    const app = express();
-    const server = app.listen(4444, () => {
-      Pyroscope.startHeapProfiling();
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          tags: { env: 'test env' },
+          heap: {
+            samplingIntervalBytes: 1024,
+          },
+          wall: {
+            samplingDurationMs: 1000,
+          },
+        });
+        Pyroscope.startHeapProfiling();
+
+        // Simulate memory usage
+        setInterval(() => {
+          // Use some memory
+          new Array<number>(2000)
+            .fill(3)
+            .reduce(
+              (previous: number, current: number): number => previous + current,
+              0
+            );
+        }, 100);
+      });
     });
 
-    let closeInvoked = false;
-
-    app.post('/ingest', (req, res) => {
-      expect(req.query['spyName']).toEqual('nodespy');
-      expect(req.query['name']).toEqual('nodejs{env=test env}');
-      res.send('ok');
-      if (!closeInvoked) {
-        closeInvoked = true;
-        (async () => {
-          await Pyroscope.stopHeapProfiling();
-          clearInterval(timer);
-          server.close(() => {
-            done();
-          });
-        })();
-      }
-    });
+    const req = await firstRequest;
+    await Pyroscope.stopHeapProfiling();
+    expect(req.query['spyName']).toBe('nodespy');
+    expect(req.query['name']).toBe('nodejs{env=test env}');
   });
 
   it('should allow to call start profiling twice', async () => {
@@ -150,144 +154,227 @@ describe('common behaviour of profilers', () => {
     clearInterval(timer);
   });
 
-  it('should have dynamic labels on wall profile', (done) => {
-    Pyroscope.init({
-      serverAddress: 'http://localhost:4446',
-      appName: 'nodejs',
-      flushIntervalMs: 100,
-      heap: {
-        samplingIntervalBytes: 1000,
-      },
-      wall: {
-        samplingDurationMs: 1000,
-        samplingIntervalMicros: 100,
-      },
-    });
-    const app = express();
-    const server = app.listen(4446, () => {
-      Pyroscope.startWallProfiling();
-      Pyroscope.wrapWithLabels(
-        {
-          vehicle: 'car',
-        },
-        () => {
-          doWork(0.2);
-          Pyroscope.wrapWithLabels(
-            {
-              brand: 'mercedes',
-            },
-            () => {
-              doWork(0.2);
-            }
-          );
+  it('should have dynamic labels on wall profile', async () => {
+    const valuesPerLabel = new Map<string, Array<number>>();
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          extractProfile(req, res, (p: Profile) => {
+            const s = (idx: Numeric): string =>
+              p.stringTable.strings[Number(idx)];
+
+            // aggregate per labels
+            p.sample.forEach((x) => {
+              const key: string = JSON.stringify(
+                x.label.reduce(
+                  (result, current) => ({
+                    ...result,
+                    [s(current.key)]: s(current.str),
+                  }),
+                  {}
+                )
+              );
+              const prev = valuesPerLabel.get(key) ?? [0, 0, 0];
+              valuesPerLabel.set(
+                key,
+                x.value.map((a, i) => Number(a) + prev[i])
+              );
+            });
+          });
+          resolve(req);
         }
       );
-    });
-    let closeInvoked = false;
-    const valuesPerLabel = new Map<string, Array<number>>();
 
-    app.post('/ingest', (req, res) => {
-      expect(req.query['spyName']).toEqual('nodespy');
-      expect(req.query['name']).toEqual('nodejs{}');
-      extractProfile(req, res, (p: Profile) => {
-        const s = (idx: Numeric): string => p.stringTable.strings[Number(idx)];
-
-        // aggregate per labels
-        p.sample.forEach((x) => {
-          const key: string = JSON.stringify(
-            x.label.reduce(
-              (result, current) => ({
-                ...result,
-                [s(current.key)]: s(current.str),
-              }),
-              {}
-            )
-          );
-          const prev = valuesPerLabel.get(key) ?? [0, 0, 0];
-          valuesPerLabel.set(
-            key,
-            x.value.map((a, i) => Number(a) + prev[i])
-          );
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          heap: {
+            samplingIntervalBytes: 1000,
+          },
+          wall: {
+            samplingDurationMs: 1000,
+            samplingIntervalMicros: 1000,
+          },
         });
+        Pyroscope.startWallProfiling();
+        Pyroscope.wrapWithLabels(
+          {
+            vehicle: 'car',
+          },
+          () => {
+            doWork(0.1);
+            Pyroscope.wrapWithLabels(
+              {
+                brand: 'mercedes',
+              },
+              () => {
+                doWork(0.1);
+              }
+            );
+          }
+        );
       });
-
-      if (!closeInvoked) {
-        closeInvoked = true;
-        (async () => {
-          await Pyroscope.stopWallProfiling();
-          server.close(() => {
-            // ensure we contain everything expected
-            const emptyLabels = JSON.stringify({});
-            const vehicleOnly = JSON.stringify({ vehicle: 'car' });
-            const vehicleAndBrand = JSON.stringify({
-              vehicle: 'car',
-              brand: 'mercedes',
-            });
-
-            expect(valuesPerLabel.keys()).toContain(emptyLabels);
-            expect(valuesPerLabel.keys()).toContain(vehicleOnly);
-            expect(valuesPerLabel.keys()).toContain(vehicleAndBrand);
-
-            const valuesVehicleOnly = valuesPerLabel.get(vehicleOnly) ?? [0, 0];
-            const valuesVehicleAndBrand = valuesPerLabel.get(
-              vehicleAndBrand
-            ) ?? [0, 0];
-
-            // ensure the wall time is within a 20% range of each other
-            const ratio = valuesVehicleOnly[1] / valuesVehicleAndBrand[1];
-            expect(ratio).toBeGreaterThan(0.8);
-            expect(ratio).toBeLessThan(1.2);
-
-            done();
-          });
-        })();
-      }
     });
+
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+
+    expect(req.query['spyName']).toEqual('nodespy');
+    expect(req.query['name']).toEqual('nodejs{}');
+
+    // ensure we contain everything expected
+    const emptyLabels = JSON.stringify({});
+    const vehicleOnly = JSON.stringify({ vehicle: 'car' });
+    const vehicleAndBrand = JSON.stringify({
+      vehicle: 'car',
+      brand: 'mercedes',
+    });
+
+    expect(valuesPerLabel.keys()).toContain(emptyLabels);
+    expect(valuesPerLabel.keys()).toContain(vehicleOnly);
+    expect(valuesPerLabel.keys()).toContain(vehicleAndBrand);
+
+    const valuesVehicleOnly = valuesPerLabel.get(vehicleOnly) ?? [0, 0];
+    const valuesVehicleAndBrand = valuesPerLabel.get(vehicleAndBrand) ?? [0, 0];
+
+    // ensure the wall time is within a 20% range of each other
+    const ratio = valuesVehicleOnly[1] / valuesVehicleAndBrand[1];
+    expect(ratio).toBeGreaterThan(0.8);
+    expect(ratio).toBeLessThan(1.2);
   });
 
-  it('should have extra samples for cpu time when enabled on wall profile', (done) => {
-    Pyroscope.init({
-      serverAddress: 'http://localhost:4447',
-      appName: 'nodejs',
-      flushIntervalMs: 100,
-      heap: {
-        samplingIntervalBytes: 1000,
-      },
-      wall: {
-        samplingDurationMs: 1000,
-        samplingIntervalMicros: 100,
-        collectCpuTime: true,
-      },
-    });
-    const app = express();
-    const server = app.listen(4447, () => {
-      Pyroscope.startWallProfiling();
-    });
-
-    let closeInvoked = false;
-    app.post('/ingest', (req, res) => {
-      expect(req.query['spyName']).toEqual('nodespy');
-      expect(req.query['name']).toEqual('nodejs{}');
-
-      extractProfile(req, res, (p: Profile) => {
-        const s = (idx: number | bigint) => p.stringTable.strings[Number(idx)];
-        // expect sample, wall and cpu types
-        expect(p.sampleType.map((x) => `${s(x.type)}=${s(x.unit)}`)).toEqual([
-          'samples=count',
-          'wall=nanoseconds',
-          'cpu=nanoseconds',
-        ]);
-      });
-
-      if (!closeInvoked) {
-        closeInvoked = true;
-        (async () => {
-          await Pyroscope.stopWallProfiling();
-          server.close(() => {
-            done();
+  it('should have extra samples for cpu time when enabled on wall profile', async () => {
+    let sampleType: string[] = [];
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          extractProfile(req, res, (p: Profile) => {
+            const s = (idx: number | bigint) =>
+              p.stringTable.strings[Number(idx)];
+            sampleType = p.sampleType.map((x) => `${s(x.type)}=${s(x.unit)}`);
           });
-        })();
-      }
+          resolve(req);
+        }
+      );
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          heap: {
+            samplingIntervalBytes: 1000,
+          },
+          wall: {
+            samplingDurationMs: 1000,
+            samplingIntervalMicros: 1000,
+            collectCpuTime: true,
+          },
+        });
+        Pyroscope.startWallProfiling();
+        doWork(0.1);
+      });
     });
+
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+
+    expect(req.query['spyName']).toEqual('nodespy');
+    expect(req.query['name']).toEqual('nodejs{}');
+    // expect sample, wall and cpu types
+    expect(sampleType).toEqual([
+      'samples=count',
+      'wall=nanoseconds',
+      'cpu=nanoseconds',
+    ]);
+  });
+
+  it('should send bearer authentication header when configured', async () => {
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          resolve(req);
+          res.send('ok');
+        }
+      );
+
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          wall: {
+            samplingDurationMs: 1000,
+          },
+          authToken: 'my-token',
+        });
+        Pyroscope.startWallProfiling();
+        doWork(0.01);
+      });
+    });
+
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+    expect(req.headers['authorization']).toBe('Bearer my-token');
+  });
+
+  it('should send basic authentication header when configured', async () => {
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          resolve(req);
+          res.send('ok');
+        }
+      );
+
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          wall: {
+            samplingDurationMs: 1000,
+          },
+          basicAuthUser: 'user',
+          basicAuthPassword: 'password',
+        });
+        Pyroscope.startWallProfiling();
+        doWork(0.01);
+      });
+    });
+
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+    expect(req.headers['authorization']).toBe('Basic dXNlcjpwYXNzd29yZA==');
+  });
+
+  it('should send x-scope-orgid header when configured', async () => {
+    const firstRequest = new Promise<express.Request>((resolve) => {
+      const port = createBackend(
+        (req: express.Request, res: express.Response) => {
+          resolve(req);
+          res.send('ok');
+        }
+      );
+
+      port.then((p: number) => {
+        Pyroscope.init({
+          serverAddress: `http://localhost:${p}`,
+          appName: 'nodejs',
+          flushIntervalMs: 100,
+          wall: {
+            samplingDurationMs: 1000,
+          },
+          tenantID: 'my-tenant-id',
+        });
+        Pyroscope.startWallProfiling();
+        doWork(0.01);
+      });
+    });
+
+    const req = await firstRequest;
+    await Pyroscope.stopWallProfiling();
+    expect(req.headers['x-scope-orgid']).toBe('my-tenant-id');
   });
 });


### PR DESCRIPTION
This task started with fix the broken basic auth, reported in #114, caused by #112

What I figured out is that our test are actually not waiting for the profile and therefore pretty useless (since #94), I fixed this as well and added authentication tests too.

Fixes #114
