### PR TITLE
Remove node 21 from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node: [18.x, 20.x, 21.x, 22.x, 23.x]
+        node: [18.x, 20.x, 22.x, 23.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is a no longer maintained release. Found out through: https://github.com/grafana/pyroscope-nodejs/pull/116
