### PR TITLE
Update @datadog/pprof to version 5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/grafana/pyroscope-nodejs/issues"
   },
   "dependencies": {
-    "@datadog/pprof": "5.4.1",
+    "@datadog/pprof": "5.9.0",
     "debug": "^4.3.3",
     "p-limit": "^3.1.0",
     "regenerator-runtime": "^0.13.11",

--- a/src/profilers/wall-profiler.ts
+++ b/src/profilers/wall-profiler.ts
@@ -22,9 +22,10 @@ export interface GenerateTimeLabelsArgs {
 }
 
 export interface TimeProfileNodeContext {
-  context: ProfilerContext;
+  context?: object;
   timestamp: bigint;
-  cpuTime: number;
+  cpuTime?: number;
+  asyncId?: number;
 }
 
 export interface ProfilerContext {
@@ -104,7 +105,8 @@ export class WallProfiler implements Profiler<WallProfilerStartArgs> {
   }
 
   private generateLabels(args: GenerateTimeLabelsArgs): LabelSet {
-    return { ...(args.context?.context?.labels ?? {}) };
+    const context = args.context?.context as ProfilerContext | undefined;
+    return { ...(context?.labels ?? {}) };
   }
 
   private innerProfile(restart: boolean): ProfileExport {

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
-"@datadog/pprof@5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.4.1.tgz#08c9bcf5d8efb2eeafdfc9f5bb5402f79fb41266"
-  integrity sha512-IvpL96e/cuh8ugP5O8Czdup7XQOLHeIDgM5pac5W7Lc1YzGe5zTtebKFpitvb1CPw1YY+1qFx0pWGgKP2kOfHg==
+"@datadog/pprof@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.9.0.tgz#beacd1507304e3490900ff39ea108e7ea772921b"
+  integrity sha512-7KretVkHUANWe31u9cGJpxmUkyrXsCD+fmlZQUz/zk9mtQNC4uBIKX53VUFfrVj/bxAhEEIPw5XTYiMc5RJLsw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
## Summary
- Upgrade @datadog/pprof dependency from 5.4.1 to 5.9.0
- Update TimeProfileNodeContext interface to match new API changes
- Ensure compatibility with the updated profiler library

## Changes
- **package.json**: Updated @datadog/pprof version
- **yarn.lock**: Updated lock file with new version
- **src/profilers/wall-profiler.ts**: Updated type definitions for compatibility:
  - Made context field optional and typed as object
  - Made cpuTime field optional
  - Added optional asyncId field
  - Updated label generation to safely handle optional context

## Test plan
- [ ] Verify build passes
- [ ] Run existing tests to ensure no regressions
- [ ] Test profiling functionality works correctly with new version

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>