### PR TITLE
chore: Disable fail-fast for test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-x64-small


### PR DESCRIPTION
Reason: to be able to see which tests actually fail