### PR TITLE
Release v0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyroscope/nodejs",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "description": "pyroscope nodejs package",
   "exports": {
     ".": {


### PR DESCRIPTION
Note that `v0.4.6` is skipped. This is because a `v0.4.6` git tag was created but the publish action failed.