### PR TITLE
chore: Upgrade to v0.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyroscope/nodejs",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "pyroscope nodejs package",
   "exports": {
     ".": {


### PR DESCRIPTION
`v0.4.8` was already released on this branch unintentionally (because of this tag: https://github.com/grafana/pyroscope-nodejs/releases/tag/v0.4.8-rc4).

To "fix" this release, this PR should be merged to `main`, and a `v0.4.8` tag should be added. The tagged commit will fail the release action since there's already a `v0.4.8` published: this is working as designed.

https://github.com/grafana/pyroscope-nodejs/pull/195 adds documentation to make the release process smoother next time.