### PR TITLE
Fix inline sourceMappingURL regex to stop at line breaks

### DIFF
--- a/src/sourcemapper.ts
+++ b/src/sourcemapper.ts
@@ -86,7 +86,7 @@ async function processSourceMap(
     // with regex find line that starts with "//# sourceMappingURL=data:application/json;base64"
     // and extract base64 string
     const base64Match = contents.match(
-      /\/\/# sourceMappingURL=data:application\/json;base64,([^ ]*)/
+      /\/\/# sourceMappingURL=data:application\/json;base64,([^\r\n]*)/
     );
     if (base64Match) {
       contents = Buffer.from(base64Match[1], 'base64').toString();


### PR DESCRIPTION
```diff
     const base64Match = contents.match(
-      /\/\/# sourceMappingURL=data:application\/json;base64,([^ ]*)/
+      /\/\/# sourceMappingURL=data:application\/json;base64,([^\r\n]*)/
     );
```

Files can contain multiple comments with `//# sourceMappingURL`, even though just one at the end is the most common. The current regex slurps up the line breaks (the actual `//` comment terminator) + potentially some JS and that crashes the base64 decode or JSON parse.