### PR TITLE
chore: disable npm/yarn lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true


### PR DESCRIPTION
Mitigates supply-chain risk from postinstall/preinstall scripts of transitive dependencies, per Grafana security guidance for CyberGrot week.

- .npmrc: ignore-scripts=true (covers npm install)
- .yarnrc: --install.ignore-scripts true (Yarn Classic v1)

@datadog/pprof ships prebuilds for all platforms so no postinstall is needed to build or download native bindings.