### PR TITLE
fix(sourcemapper): tighten inline base64 capture to the base64 alphabet

### DIFF
--- a/src/sourcemapper.ts
+++ b/src/sourcemapper.ts
@@ -86,7 +86,7 @@ async function processSourceMap(
     // with regex find line that starts with "//# sourceMappingURL=data:application/json;base64"
     // and extract base64 string
     const base64Match = contents.match(
-      /\/\/# sourceMappingURL=data:application\/json;base64,([^\r\n]*)/
+      /\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]*)/
     );
     if (base64Match) {
       contents = Buffer.from(base64Match[1], 'base64').toString();

--- a/src/sourcemapper.ts
+++ b/src/sourcemapper.ts
@@ -86,7 +86,7 @@ async function processSourceMap(
     // with regex find line that starts with "//# sourceMappingURL=data:application/json;base64"
     // and extract base64 string
     const base64Match = contents.match(
-      /\/\/# sourceMappingURL=data:application\/json;base64,([^ ]*)/
+      /\/\/# sourceMappingURL=data:application\/json;base64,([^\r\n]*)/
     );
     if (base64Match) {
       contents = Buffer.from(base64Match[1], 'base64').toString();

--- a/test/sourcemapper.test.ts
+++ b/test/sourcemapper.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { SourceMapper } from '../src/sourcemapper.ts';
+
+function buildMinimalSourceMap(file: string): string {
+  // sourceRoot filler is sized so the JSON length is divisible by 3 — the
+  // resulting base64 has no '=' padding. Without padding, Node's lenient
+  // base64 decoder keeps decoding past the legitimate payload into any
+  // trailing garbage. That makes the over-capture from the pre-fix regex
+  // (which slurped past the line break into the next directive) corrupt
+  // the decoded JSON instead of being silently truncated at the padding.
+  for (let pad = 0; pad < 3; pad++) {
+    const json = JSON.stringify({
+      version: 3,
+      file,
+      sources: [file.replace(/\.js$/, '.ts')],
+      names: [],
+      mappings: '',
+      sourceRoot: 'a'.repeat(pad),
+    });
+    if (!Buffer.from(json).toString('base64').endsWith('=')) {
+      return json;
+    }
+  }
+  throw new Error(
+    'failed to pad source map JSON to a length without base64 padding'
+  );
+}
+
+function buildJsWithInlineSourceMap(
+  sourceMapJson: string,
+  {
+    directiveCount = 1,
+    trailingOnDirectiveLine = '',
+  }: { directiveCount?: number; trailingOnDirectiveLine?: string } = {}
+): string {
+  const base64 = Buffer.from(sourceMapJson).toString('base64');
+  const directives = Array.from(
+    { length: directiveCount },
+    () =>
+      `//# sourceMappingURL=data:application/json;base64,${base64}${trailingOnDirectiveLine}`
+  ).join('\n');
+  return `console.log('hi');\n${directives}\n`;
+}
+
+describe('SourceMapper inline base64 sourcemap', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyroscope-sm-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses a single inline //# sourceMappingURL= directive', async () => {
+    const jsFile = path.join(tmpDir, 'app.js');
+    fs.writeFileSync(
+      jsFile,
+      buildJsWithInlineSourceMap(buildMinimalSourceMap('app.js'))
+    );
+
+    const mapper = await SourceMapper.create([tmpDir]);
+
+    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+  });
+
+  // Regression test for the regex at sourcemapper.ts:89. Some bundlers (or
+  // files concatenated from multiple bundles) emit more than one
+  // //# sourceMappingURL=data:... directive in a single file. A [^ ]*
+  // terminator does not stop at line breaks, so it greedily consumes
+  // across the second directive, producing invalid base64.
+  it('parses inline sourceMappingURL when the file emits the directive twice', async () => {
+    const jsFile = path.join(tmpDir, 'multi.js');
+    fs.writeFileSync(
+      jsFile,
+      buildJsWithInlineSourceMap(buildMinimalSourceMap('multi.js'), {
+        directiveCount: 2,
+      })
+    );
+
+    const mapper = await SourceMapper.create([tmpDir]);
+
+    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+  });
+
+  // The capture must also terminate at non-base64 characters that appear on
+  // the same line as the directive. A [^\r\n]* terminator would swallow a
+  // trailing inline comment, producing trailing chars that decode to garbage
+  // appended to the JSON payload.
+  it('parses inline sourceMappingURL with a trailing inline comment on the same line', async () => {
+    const jsFile = path.join(tmpDir, 'trailing.js');
+    fs.writeFileSync(
+      jsFile,
+      buildJsWithInlineSourceMap(buildMinimalSourceMap('trailing.js'), {
+        trailingOnDirectiveLine: ' // extra',
+      })
+    );
+
+    const mapper = await SourceMapper.create([tmpDir]);
+
+    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Tighten the inline `//# sourceMappingURL=data:application/json;base64,` regex from `[^\r\n]*` to `[A-Za-z0-9+/=]*` so the capture terminates at any non-base64 byte (line breaks, spaces, tabs, or trailing text).
- Add `test/sourcemapper.test.ts` with three regression cases against `SourceMapper.create`: a single directive, two directives in the same file (multi-emission, #257's case), and a directive followed by trailing non-base64 content on the same line.

Supersedes #257. Builds on top of @functorism's commit `8effa95` so the original authorship and motivation are preserved in history. The original PR's regex (`[^\r\n]*`) correctly stops at line breaks but still admits any non-newline byte into the capture, so a trailing inline comment (or even a tab) on the directive line gets decoded as additional base64 and corrupts the JSON payload. Using the base64 alphabet directly resolves both the multi-emission case and the trailing-content case in one step.

## Why not just `[^\r\n]*`?

| Trailing content after the base64 on the same line | Old `[^ ]*` | #257's `[^\r\n]*` | This PR `[A-Za-z0-9+/=]*` |
|---|---|---|---|
| Trailing spaces before newline | OK (stops at space) | OK (whitespace is ignored by base64 decode) | OK |
| Trailing tab before newline | Broken (tab isn't space) | OK | OK |
| Trailing ` // comment` | OK | Broken (`/` is valid base64; `// comment` is captured and decoded) | OK |
| Two `//# sourceMappingURL=…` directives in one file | Broken (capture crosses newlines) | OK | OK |

## Test plan

- [x] `vitest run test/sourcemapper.test.ts` passes (3/3) on HEAD.
- [x] Verified each test fails on the corresponding weaker regex by temporarily reverting `src/sourcemapper.ts` to `[^ ]*` and to `[^\r\n]*` in turn — the multi-directive test fails on `[^ ]*`, the trailing-comment test fails on `[^\r\n]*`, and both pass on `[A-Za-z0-9+/=]*`.
- [x] Full suite (`vitest run`) — all 19 non-fastify tests pass. The pre-existing `test/fastify.test.ts` Vite peer-dep resolution error is unrelated to this change.