### PR TITLE
chore: disable npm/yarn lifecycle scripts

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
+enableScripts: false
 nodeLinker: node-modules


### PR DESCRIPTION
Follow up to #259, we are actually use yarn 4 which ignores `.yarnrc`