### PR TITLE
Trim dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist-test
 
 # Gatsby files
 .cache/

--- a/config/tsconfig.test.json
+++ b/config/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "../dist-test",
+    "rootDir": ".."
+  },
+  "include": ["../src/**/*", "../test/**/*.ts", "../test/**/*.d.ts"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ module.exports = [
       '**/*.test.js',
       '**/*.test.ts',
       'dist/**',
+      'dist-test/**',
     ],
   },
   ...tsEslintPlugin.configs['flat/recommended'],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/busboy": "^1.5.4",
     "@types/debug": "^4.1.12",
     "@types/source-map": "^0.5.7",
-    "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "busboy": "^1.6.0",
@@ -66,7 +65,6 @@
     "pinst": "^3.0.0",
     "pprof-format": "^2.2.1",
     "prettier": "^3.8.1",
-    "supertest": "^7.2.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "format:fix": "prettier --write .",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
-    "test": "vitest",
-    "test:cov": "vitest run --coverage",
+    "build:test": "node tools/cleanup dist-test && tsc -p config/tsconfig.test.json && echo '{\"type\":\"module\"}' >./dist-test/package.json",
+    "test": "yarn build:test && node --test dist-test/test/*.test.js",
+    "test:cov": "yarn build:test && node --test --experimental-test-coverage dist-test/test/*.test.js",
     "addscope": "node tools/packagejson name @pyroscope"
   },
   "publishConfig": {
@@ -55,7 +56,6 @@
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
-    "@vitest/coverage-v8": "^4.1.2",
     "busboy": "^1.6.0",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
@@ -67,8 +67,7 @@
     "pprof-format": "^2.2.1",
     "prettier": "^3.8.1",
     "supertest": "^7.2.2",
-    "typescript": "^5.9.3",
-    "vitest": "^4.1.2"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "express": "^4.0.0 || ^5.0.0",

--- a/test/_ambient.d.ts
+++ b/test/_ambient.d.ts
@@ -1,0 +1,14 @@
+declare namespace express {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type Request = any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type Response = any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type RequestHandler = any;
+}
+
+declare module 'express' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const express: any;
+  export = express;
+}

--- a/test/express.test.ts
+++ b/test/express.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
 
 import Pyroscope from '../src/index.js';
 import request from 'supertest';
@@ -9,7 +10,7 @@ Pyroscope.init();
 
 describe('express middleware', () => {
   it('should be a function', () => {
-    expect(typeof Pyroscope.expressMiddleware).toBe('function');
+    assert.strictEqual(typeof Pyroscope.expressMiddleware, 'function');
   });
   it('should respond to cpu calls', async () => {
     const app = express();
@@ -17,10 +18,10 @@ describe('express middleware', () => {
     return request(app)
       .get('/debug/pprof/profile?seconds=1')
       .then((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       })
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
   });
   it('should respond to repetitive cpu calls', async () => {
@@ -29,10 +30,10 @@ describe('express middleware', () => {
     return request(app)
       .get('/debug/pprof/profile?seconds=1')
       .then((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       })
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
   });
 
@@ -44,18 +45,18 @@ describe('express middleware', () => {
   //     request(app)
   //       .get('/debug/pprof/profile?seconds=1')
   //       .then((result) => {
-  //         expect(result.statusCode).toBe(200)
+  //         assert.strictEqual(result.statusCode, 200)
   //       })
   //       .catch((result) => {
-  //         expect(result.statusCode).toBe(200)
+  //         assert.strictEqual(result.statusCode, 200)
   //       }),
   //     request(app)
   //       .get('/debug/pprof/profile?seconds=1')
   //       .then((result) => {
-  //         expect(result.statusCode).toBe(200)
+  //         assert.strictEqual(result.statusCode, 200)
   //       })
   //       .catch((result) => {
-  //         expect(result.statusCode).toBe(200)
+  //         assert.strictEqual(result.statusCode, 200)
   //       }),
   //   ])
   // })
@@ -64,9 +65,9 @@ describe('express middleware', () => {
     app.use(Pyroscope.expressMiddleware());
     return request(app)
       .get('/debug/pprof/heap')
-      .then((result) => expect(result.statusCode).toBe(200))
+      .then((result) => assert.strictEqual(result.statusCode, 200))
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
   });
   it('should respond to repetitive heap profiling calls', () => {
@@ -74,27 +75,27 @@ describe('express middleware', () => {
     app.use(Pyroscope.expressMiddleware());
     return request(app)
       .get('/debug/pprof/heap')
-      .then((result) => expect(result.statusCode).toBe(200))
+      .then((result) => assert.strictEqual(result.statusCode, 200))
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
   });
 
-  it('should respond to simultaneous heap profiling calls', () => {
+  it('should respond to simultaneous heap profiling calls', async () => {
     const app = express();
     app.use(Pyroscope.expressMiddleware());
-    return Promise.all([
+    await Promise.all([
       request(app)
         .get('/debug/pprof/heap?seconds=1')
-        .then((result) => expect(result.statusCode).toBe(200))
+        .then((result) => assert.strictEqual(result.statusCode, 200))
         .catch((result) => {
-          expect(result.statusCode).toBe(200);
+          assert.strictEqual(result.statusCode, 200);
         }),
       request(app)
         .get('/debug/pprof/heap?seconds=1')
-        .then((result) => expect(result.statusCode).toBe(200))
+        .then((result) => assert.strictEqual(result.statusCode, 200))
         .catch((result) => {
-          expect(result.statusCode).toBe(200);
+          assert.strictEqual(result.statusCode, 200);
         }),
     ]);
   });
@@ -108,16 +109,16 @@ describe('express middleware', () => {
 
     request(app)
       .get('/debug/pprof/heap')
-      .then((result) => expect(result.statusCode).toBe(200))
+      .then((result) => assert.strictEqual(result.statusCode, 200))
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
 
     request(app2)
       .get('/debug/pprof/heap')
-      .then((result) => expect(result.statusCode).toBe(200))
+      .then((result) => assert.strictEqual(result.statusCode, 200))
       .catch((result) => {
-        expect(result.statusCode).toBe(200);
+        assert.strictEqual(result.statusCode, 200);
       });
   });
 });

--- a/test/express.test.ts
+++ b/test/express.test.ts
@@ -1,124 +1,122 @@
-import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { createServer, type Server } from 'node:http';
+import { describe, it } from 'node:test';
 
-import Pyroscope from '../src/index.js';
-import request from 'supertest';
 import express from 'express';
+import Pyroscope from '../src/index.js';
 
 // You only need appName for the pull mode
 Pyroscope.init();
+
+type ExpressApp = ReturnType<typeof express>;
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function withServer(
+  app: ExpressApp,
+  fn: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const server = createServer(app);
+  const baseUrl = await listen(server);
+
+  try {
+    await fn(baseUrl);
+  } finally {
+    await close(server);
+  }
+}
+
+async function fetchStatus(baseUrl: string, path: string): Promise<number> {
+  const response = await fetch(new URL(path, baseUrl));
+  await response.arrayBuffer();
+  return response.status;
+}
+
+function appWithMiddleware(): ExpressApp {
+  const app = express();
+  app.use(Pyroscope.expressMiddleware());
+  return app;
+}
 
 describe('express middleware', () => {
   it('should be a function', () => {
     assert.strictEqual(typeof Pyroscope.expressMiddleware, 'function');
   });
+
   it('should respond to cpu calls', async () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-    return request(app)
-      .get('/debug/pprof/profile?seconds=1')
-      .then((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      })
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
-  });
-  it('should respond to repetitive cpu calls', async () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-    return request(app)
-      .get('/debug/pprof/profile?seconds=1')
-      .then((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      })
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
+    await withServer(appWithMiddleware(), async (baseUrl) => {
+      assert.strictEqual(
+        await fetchStatus(baseUrl, '/debug/pprof/profile?seconds=1'),
+        200
+      );
+    });
   });
 
-  // it('should respond to simultaneous cpu calls', () => {
-  //   const app = express()
-  //   app.use(Pyroscope.expressMiddleware())
-  //   console.log('0', Date.now()/1000);
-  //   return Promise.all([
-  //     request(app)
-  //       .get('/debug/pprof/profile?seconds=1')
-  //       .then((result) => {
-  //         assert.strictEqual(result.statusCode, 200)
-  //       })
-  //       .catch((result) => {
-  //         assert.strictEqual(result.statusCode, 200)
-  //       }),
-  //     request(app)
-  //       .get('/debug/pprof/profile?seconds=1')
-  //       .then((result) => {
-  //         assert.strictEqual(result.statusCode, 200)
-  //       })
-  //       .catch((result) => {
-  //         assert.strictEqual(result.statusCode, 200)
-  //       }),
-  //   ])
-  // })
-  it('should respond to heap profiling calls', () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-    return request(app)
-      .get('/debug/pprof/heap')
-      .then((result) => assert.strictEqual(result.statusCode, 200))
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
+  it('should respond to repetitive cpu calls', async () => {
+    await withServer(appWithMiddleware(), async (baseUrl) => {
+      assert.strictEqual(
+        await fetchStatus(baseUrl, '/debug/pprof/profile?seconds=1'),
+        200
+      );
+    });
   });
-  it('should respond to repetitive heap profiling calls', () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-    return request(app)
-      .get('/debug/pprof/heap')
-      .then((result) => assert.strictEqual(result.statusCode, 200))
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
+
+  it('should respond to heap profiling calls', async () => {
+    await withServer(appWithMiddleware(), async (baseUrl) => {
+      assert.strictEqual(await fetchStatus(baseUrl, '/debug/pprof/heap'), 200);
+    });
+  });
+
+  it('should respond to repetitive heap profiling calls', async () => {
+    await withServer(appWithMiddleware(), async (baseUrl) => {
+      assert.strictEqual(await fetchStatus(baseUrl, '/debug/pprof/heap'), 200);
+    });
   });
 
   it('should respond to simultaneous heap profiling calls', async () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-    await Promise.all([
-      request(app)
-        .get('/debug/pprof/heap?seconds=1')
-        .then((result) => assert.strictEqual(result.statusCode, 200))
-        .catch((result) => {
-          assert.strictEqual(result.statusCode, 200);
-        }),
-      request(app)
-        .get('/debug/pprof/heap?seconds=1')
-        .then((result) => assert.strictEqual(result.statusCode, 200))
-        .catch((result) => {
-          assert.strictEqual(result.statusCode, 200);
-        }),
-    ]);
+    await withServer(appWithMiddleware(), async (baseUrl) => {
+      const [response1, response2] = await Promise.all([
+        fetchStatus(baseUrl, '/debug/pprof/heap?seconds=1'),
+        fetchStatus(baseUrl, '/debug/pprof/heap?seconds=1'),
+      ]);
+
+      assert.strictEqual(response1, 200);
+      assert.strictEqual(response2, 200);
+    });
   });
 
-  it('should be fine using two middlewares at the same time', () => {
-    const app = express();
-    app.use(Pyroscope.expressMiddleware());
-
-    const app2 = express();
-    app2.use(Pyroscope.expressMiddleware());
-
-    request(app)
-      .get('/debug/pprof/heap')
-      .then((result) => assert.strictEqual(result.statusCode, 200))
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
-
-    request(app2)
-      .get('/debug/pprof/heap')
-      .then((result) => assert.strictEqual(result.statusCode, 200))
-      .catch((result) => {
-        assert.strictEqual(result.statusCode, 200);
-      });
+  it('should be fine using two middlewares at the same time', async () => {
+    await Promise.all([
+      withServer(appWithMiddleware(), async (baseUrl) => {
+        assert.strictEqual(await fetchStatus(baseUrl, '/debug/pprof/heap'), 200);
+      }),
+      withServer(appWithMiddleware(), async (baseUrl) => {
+        assert.strictEqual(await fetchStatus(baseUrl, '/debug/pprof/heap'), 200);
+      }),
+    ]);
   });
 });

--- a/test/fastify.test.ts
+++ b/test/fastify.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
 
 import Pyroscope from '../src/index.js';
 import Fastify from 'fastify';
@@ -8,7 +9,7 @@ Pyroscope.init();
 
 describe('fastify middleware', () => {
   it('should be a function', () => {
-    expect(typeof Pyroscope.fastifyMiddleware).toBe('function');
+    assert.strictEqual(typeof Pyroscope.fastifyMiddleware, 'function');
   });
   it('should respond to cpu calls', async () => {
     const app = Fastify();
@@ -17,7 +18,7 @@ describe('fastify middleware', () => {
       method: 'GET',
       url: '/debug/pprof/profile?seconds=1',
     });
-    expect(response.statusCode).toBe(200);
+    assert.strictEqual(response.statusCode, 200);
   });
   it('should respond to repetitive cpu calls', async () => {
     const app = Fastify();
@@ -26,7 +27,7 @@ describe('fastify middleware', () => {
       method: 'GET',
       url: '/debug/pprof/profile?seconds=1',
     });
-    expect(response.statusCode).toBe(200);
+    assert.strictEqual(response.statusCode, 200);
   });
 
   // it('should respond to simultaneous cpu calls', async () => {
@@ -43,8 +44,8 @@ describe('fastify middleware', () => {
   //       url: '/debug/pprof/profile?seconds=1'
   //     }),
   //   ])
-  //   expect(response1.statusCode).toBe(200)
-  //   expect(response2.statusCode).toBe(200)
+  //   assert.strictEqual(response1.statusCode, 200)
+  //   assert.strictEqual(response2.statusCode, 200)
   // })
   it('should respond to heap profiling calls', async () => {
     const app = Fastify();
@@ -53,7 +54,7 @@ describe('fastify middleware', () => {
       method: 'GET',
       url: '/debug/pprof/heap',
     });
-    expect(response.statusCode).toBe(200);
+    assert.strictEqual(response.statusCode, 200);
   });
   it('should respond to repetitive heap profiling calls', async () => {
     const app = Fastify();
@@ -62,7 +63,7 @@ describe('fastify middleware', () => {
       method: 'GET',
       url: '/debug/pprof/heap',
     });
-    expect(response.statusCode).toBe(200);
+    assert.strictEqual(response.statusCode, 200);
   });
 
   it('should respond to simultaneous heap profiling calls', async () => {
@@ -78,8 +79,8 @@ describe('fastify middleware', () => {
         url: '/debug/pprof/heap?seconds=1',
       }),
     ]);
-    expect(response1.statusCode).toBe(200);
-    expect(response2.statusCode).toBe(200);
+    assert.strictEqual(response1.statusCode, 200);
+    assert.strictEqual(response2.statusCode, 200);
   });
 
   it('should be fine using two middlewares at the same time', async () => {
@@ -93,12 +94,12 @@ describe('fastify middleware', () => {
       method: 'GET',
       url: '/debug/pprof/heap',
     });
-    expect(response1.statusCode).toBe(200);
+    assert.strictEqual(response1.statusCode, 200);
 
     const response2 = await app2.inject({
       method: 'GET',
       url: '/debug/pprof/heap',
     });
-    expect(response2.statusCode).toBe(200);
+    assert.strictEqual(response2.statusCode, 200);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,37 +1,40 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
 
 import fs from 'node:fs';
 import { Profile } from 'pprof-format';
-import Pyroscope from '../src/index.ts';
-import { processProfile } from '../src/utils/process-profile.ts';
+import Pyroscope from '../src/index.js';
+import { processProfile } from '../src/utils/process-profile.js';
 
 describe('typescript env', () => {
   it('has correct imports', () => {
-    expect(Pyroscope.init).toBeInstanceOf(Function);
-    expect(Pyroscope.startWallProfiling).toBeInstanceOf(Function);
-    expect(Pyroscope.stopWallProfiling).toBeInstanceOf(Function);
-    expect(Pyroscope.startHeapProfiling).toBeInstanceOf(Function);
-    expect(Pyroscope.stopHeapProfiling).toBeInstanceOf(Function);
+    assert.strictEqual(typeof Pyroscope.init, 'function');
+    assert.strictEqual(typeof Pyroscope.startWallProfiling, 'function');
+    assert.strictEqual(typeof Pyroscope.stopWallProfiling, 'function');
+    assert.strictEqual(typeof Pyroscope.startHeapProfiling, 'function');
+    assert.strictEqual(typeof Pyroscope.stopHeapProfiling, 'function');
 
-    expect(Pyroscope.expressMiddleware).toBeInstanceOf(Function);
+    assert.strictEqual(typeof Pyroscope.expressMiddleware, 'function');
   });
 
   it('can process profile', () => {
     const profile = Profile.decode(fs.readFileSync('./test/profile1.data'));
     const newProfile = processProfile(profile);
 
-    expect(newProfile.stringTable.strings.length).toBe(20);
+    assert.strictEqual(newProfile.stringTable.strings.length, 20);
 
     // Check we're receiving right data
-    expect(newProfile.stringTable.strings).toContain(
-      'node:internal/modules/run_main'
+    assert.ok(
+      newProfile.stringTable.strings.includes('node:internal/modules/run_main')
     );
-    expect(newProfile.stringTable.strings).toContain(
-      '/home/korniltsev/pyroscope/pyroscope-nodejs/dist/cjs/cpu.js'
+    assert.ok(
+      newProfile.stringTable.strings.includes(
+        '/home/korniltsev/pyroscope/pyroscope-nodejs/dist/cjs/cpu.js'
+      )
     );
 
     // // Check profiles replacement works
-    expect(profile.stringTable.strings).toContain('sample');
-    expect(newProfile.stringTable.strings).toContain('samples');
+    assert.ok(profile.stringTable.strings.includes('sample'));
+    assert.ok(newProfile.stringTable.strings.includes('samples'));
   });
 });

--- a/test/profiler.test.ts
+++ b/test/profiler.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, onTestFinished } from 'vitest';
+import { describe, it, type TestContext } from 'node:test';
+import { strict as assert } from 'node:assert';
 
 import Pyroscope from '../src/index.js';
 import express from 'express';
@@ -8,7 +9,10 @@ import zlib from 'zlib';
 
 // createBackend creates an Express server with an /ingest endpoint and returns a promise
 // that resolves to the HTTP port the server is listening on
-const createBackend = (handler: express.RequestHandler): Promise<number> => {
+const createBackend = (
+  t: TestContext,
+  handler: express.RequestHandler
+): Promise<number> => {
   const server = express();
   const port = new Promise<number>((resolvePort, rejectPort) => {
     const httpServer = server.listen(0, () => {
@@ -19,7 +23,7 @@ const createBackend = (handler: express.RequestHandler): Promise<number> => {
         rejectPort('Could not resolve port');
       }
     });
-    onTestFinished(() => {
+    t.after(() => {
       httpServer.close();
     });
   });
@@ -56,9 +60,10 @@ const doWork = (d: number): void => {
 };
 
 describe('common behaviour of profilers', () => {
-  it('should call a server on startCpuProfiling and clear gracefully', async () => {
+  it('should call a server on startCpuProfiling and clear gracefully', async (t) => {
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           resolve(req);
           res.send('ok');
@@ -81,13 +86,21 @@ describe('common behaviour of profilers', () => {
 
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
-    expect(req.query.spyName).toBe('nodespy');
-    expect(req.query.name).toBe('nodejs{}');
+    assert.strictEqual(req.query.spyName, 'nodespy');
+    assert.strictEqual(req.query.name, 'nodejs{}');
   });
 
-  it('should call a server on startHeapProfiling and clear gracefully', async () => {
+  it('should call a server on startHeapProfiling and clear gracefully', async (t) => {
+    let timer: NodeJS.Timeout | undefined;
+    t.after(() => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           resolve(req);
           res.send('ok');
@@ -110,7 +123,7 @@ describe('common behaviour of profilers', () => {
         Pyroscope.startHeapProfiling();
 
         // Simulate memory usage
-        setInterval(() => {
+        timer = setInterval(() => {
           // Use some memory
           new Array<number>(2000)
             .fill(3)
@@ -124,11 +137,11 @@ describe('common behaviour of profilers', () => {
 
     const req = await firstRequest;
     await Pyroscope.stopHeapProfiling();
-    expect(req.query['spyName']).toBe('nodespy');
-    expect(req.query['name']).toBe('nodejs{env=test env}');
+    assert.strictEqual(req.query['spyName'], 'nodespy');
+    assert.strictEqual(req.query['name'], 'nodejs{env=test env}');
   });
 
-  it('should allow to call start profiling twice', async () => {
+  it('should allow to call start profiling twice', async (t) => {
     // Simulate memory usage
     const timer: NodeJS.Timeout = setInterval(() => {
       // Use some memory
@@ -139,6 +152,7 @@ describe('common behaviour of profilers', () => {
           0
         );
     }, 100);
+    t.after(() => clearInterval(timer));
 
     Pyroscope.init({
       serverAddress: 'http://localhost:4444',
@@ -162,10 +176,11 @@ describe('common behaviour of profilers', () => {
     clearInterval(timer);
   });
 
-  it('should have dynamic labels on wall profile', async () => {
+  it('should have dynamic labels on wall profile', async (t) => {
     const valuesPerLabel = new Map<string, Array<number>>();
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           extractProfile(req, res, (p: Profile) => {
             const s = (idx: Numeric): string =>
@@ -229,8 +244,8 @@ describe('common behaviour of profilers', () => {
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
 
-    expect(req.query['spyName']).toEqual('nodespy');
-    expect(req.query['name']).toEqual('nodejs{}');
+    assert.strictEqual(req.query['spyName'], 'nodespy');
+    assert.strictEqual(req.query['name'], 'nodejs{}');
 
     // ensure we contain everything expected
     const emptyLabels = JSON.stringify({});
@@ -240,23 +255,24 @@ describe('common behaviour of profilers', () => {
       brand: 'mercedes',
     });
 
-    expect(valuesPerLabel.keys()).toContain(emptyLabels);
-    expect(valuesPerLabel.keys()).toContain(vehicleOnly);
-    expect(valuesPerLabel.keys()).toContain(vehicleAndBrand);
+    assert.ok(valuesPerLabel.has(emptyLabels));
+    assert.ok(valuesPerLabel.has(vehicleOnly));
+    assert.ok(valuesPerLabel.has(vehicleAndBrand));
 
     const valuesVehicleOnly = valuesPerLabel.get(vehicleOnly) ?? [0, 0];
     const valuesVehicleAndBrand = valuesPerLabel.get(vehicleAndBrand) ?? [0, 0];
 
     // ensure the wall time is within a 20% range of each other
     const ratio = valuesVehicleOnly[1] / valuesVehicleAndBrand[1];
-    expect(ratio).toBeGreaterThan(0.8);
-    expect(ratio).toBeLessThan(1.2);
+    assert.ok(ratio > 0.8, `expected ${ratio} > 0.8`);
+    assert.ok(ratio < 1.2, `expected ${ratio} < 1.2`);
   });
 
-  it('should have extra samples for cpu time when enabled on wall profile', async () => {
+  it('should have extra samples for cpu time when enabled on wall profile', async (t) => {
     let sampleType: string[] = [];
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           extractProfile(req, res, (p: Profile) => {
             const s = (idx: number | bigint) =>
@@ -288,19 +304,20 @@ describe('common behaviour of profilers', () => {
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
 
-    expect(req.query['spyName']).toEqual('nodespy');
-    expect(req.query['name']).toEqual('nodejs{}');
+    assert.strictEqual(req.query['spyName'], 'nodespy');
+    assert.strictEqual(req.query['name'], 'nodejs{}');
     // expect sample, wall and cpu types
-    expect(sampleType).toEqual([
+    assert.deepStrictEqual(sampleType, [
       'samples=count',
       'wall=nanoseconds',
       'cpu=nanoseconds',
     ]);
   });
 
-  it('should send bearer authentication header when configured', async () => {
+  it('should send bearer authentication header when configured', async (t) => {
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           resolve(req);
           res.send('ok');
@@ -324,12 +341,13 @@ describe('common behaviour of profilers', () => {
 
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
-    expect(req.headers['authorization']).toBe('Bearer my-token');
+    assert.strictEqual(req.headers['authorization'], 'Bearer my-token');
   });
 
-  it('should send basic authentication header when configured', async () => {
+  it('should send basic authentication header when configured', async (t) => {
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           resolve(req);
           res.send('ok');
@@ -354,12 +372,16 @@ describe('common behaviour of profilers', () => {
 
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
-    expect(req.headers['authorization']).toBe('Basic dXNlcjpwYXNzd29yZA==');
+    assert.strictEqual(
+      req.headers['authorization'],
+      'Basic dXNlcjpwYXNzd29yZA=='
+    );
   });
 
-  it('should send x-scope-orgid header when configured', async () => {
+  it('should send x-scope-orgid header when configured', async (t) => {
     const firstRequest = new Promise<express.Request>((resolve) => {
       const port = createBackend(
+        t,
         (req: express.Request, res: express.Response) => {
           resolve(req);
           res.send('ok');
@@ -383,6 +405,6 @@ describe('common behaviour of profilers', () => {
 
     const req = await firstRequest;
     await Pyroscope.stopWallProfiling();
-    expect(req.headers['x-scope-orgid']).toBe('my-tenant-id');
+    assert.strictEqual(req.headers['x-scope-orgid'], 'my-tenant-id');
   });
 });

--- a/test/sourcemapper.test.ts
+++ b/test/sourcemapper.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { SourceMapper } from '../src/sourcemapper.ts';
+import { SourceMapper } from '../src/sourcemapper.js';
 
 function buildMinimalSourceMap(file: string): string {
   // sourceRoot filler is sized so the JSON length is divisible by 3 — the
@@ -67,7 +68,7 @@ describe('SourceMapper inline base64 sourcemap', () => {
 
     const mapper = await SourceMapper.create([tmpDir]);
 
-    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+    assert.strictEqual(mapper.hasMappingInfo(jsFile), true);
   });
 
   // Regression test for the regex at sourcemapper.ts:89. Some bundlers (or
@@ -86,7 +87,7 @@ describe('SourceMapper inline base64 sourcemap', () => {
 
     const mapper = await SourceMapper.create([tmpDir]);
 
-    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+    assert.strictEqual(mapper.hasMappingInfo(jsFile), true);
   });
 
   // The capture must also terminate at non-base64 characters that appear on
@@ -104,6 +105,6 @@ describe('SourceMapper inline base64 sourcemap', () => {
 
     const mapper = await SourceMapper.create([tmpDir]);
 
-    expect(mapper.hasMappingInfo(jsFile)).toBe(true);
+    assert.strictEqual(mapper.hasMappingInfo(jsFile), true);
   });
 });

--- a/tools/cleanup.js
+++ b/tools/cleanup.js
@@ -19,7 +19,9 @@ const deleteFolderRecursive = (path) => {
 
 const folder = process.argv.slice(2)[0];
 
-if (folder) {
+if (folder === 'dist-test') {
+  deleteFolderRecursive(Path.join(__dirname, '../dist-test'));
+} else if (folder) {
   deleteFolderRecursive(Path.join(__dirname, '../dist', folder));
 } else {
   deleteFolderRecursive(Path.join(__dirname, '../dist/cjs'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,13 +188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.1.5":
-  version: 1.8.0
-  resolution: "@noble/hashes@npm:1.8.0"
-  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
-  languageName: node
-  linkType: hard
-
 "@npmcli/agent@npm:^4.0.0":
   version: 4.0.0
   resolution: "@npmcli/agent@npm:4.0.0"
@@ -224,15 +217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@paralleldrive/cuid2@npm:^2.2.2":
-  version: 2.3.1
-  resolution: "@paralleldrive/cuid2@npm:2.3.1"
-  dependencies:
-    "@noble/hashes": "npm:^1.1.5"
-  checksum: 10c0/6576b73de49d826b0f33cbab88424dec1f6fa454a9e59a7b621f78c2cfdd2e59d7f48175826d698940a717f45eeb5e87a508583a7316e608f6a05a861a40c129
-  languageName: node
-  linkType: hard
-
 "@pinojs/redact@npm:^0.4.0":
   version: 0.4.0
   resolution: "@pinojs/redact@npm:0.4.0"
@@ -255,7 +239,6 @@ __metadata:
     "@types/busboy": "npm:^1.5.4"
     "@types/debug": "npm:^4.1.12"
     "@types/source-map": "npm:^0.5.7"
-    "@types/supertest": "npm:^6.0.3"
     "@typescript-eslint/eslint-plugin": "npm:^8.58.0"
     "@typescript-eslint/parser": "npm:^8.58.0"
     busboy: "npm:^1.6.0"
@@ -272,7 +255,6 @@ __metadata:
     prettier: "npm:^3.8.1"
     regenerator-runtime: "npm:^0.14.1"
     source-map: "npm:^0.7.6"
-    supertest: "npm:^7.2.2"
     typescript: "npm:^5.9.3"
   peerDependencies:
     express: ^4.0.0 || ^5.0.0
@@ -291,13 +273,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/0bdd209069a445d5a71277e558978ec0db1b1a3d108335da96477d017177ae349c4d81d604db0bea19e3c99c10af2d60dbac20e36cef7cb7a517e5a4760738bd
-  languageName: node
-  linkType: hard
-
-"@types/cookiejar@npm:^2.1.5":
-  version: 2.1.5
-  resolution: "@types/cookiejar@npm:2.1.5"
-  checksum: 10c0/af38c3d84aebb3ccc6e46fb6afeeaac80fb26e63a487dd4db5a8b87e6ad3d4b845ba1116b2ae90d6f886290a36200fa433d8b1f6fe19c47da6b81872ce9a2764
   languageName: node
   linkType: hard
 
@@ -331,13 +306,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/methods@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@types/methods@npm:1.1.4"
-  checksum: 10c0/a78534d79c300718298bfff92facd07bf38429c66191f640c1db4c9cff1e36f819304298a96f7536b6512bfc398e5c3e6b831405e138cd774b88ad7be78d682a
-  languageName: node
-  linkType: hard
-
 "@types/ms@npm:*":
   version: 2.1.0
   resolution: "@types/ms@npm:2.1.0"
@@ -360,28 +328,6 @@ __metadata:
   dependencies:
     source-map: "npm:*"
   checksum: 10c0/e7d67b93ab0a10e2d13800fe4310328fb4408b75631af7bc77548225dba2dc31c678d251fb7449366af4af9cf638fadb6829c5a22b760af75750ffb989f27af6
-  languageName: node
-  linkType: hard
-
-"@types/superagent@npm:^8.1.0":
-  version: 8.1.9
-  resolution: "@types/superagent@npm:8.1.9"
-  dependencies:
-    "@types/cookiejar": "npm:^2.1.5"
-    "@types/methods": "npm:^1.1.4"
-    "@types/node": "npm:*"
-    form-data: "npm:^4.0.0"
-  checksum: 10c0/12631f1d8b3a62e1f435bc885f6d64d1a2d1ae82b80f0c6d63d4d6372c40b6f1fee6b3da59ac18bb86250b1eb73583bf2d4b1f7882048c32468791c560c69b7c
-  languageName: node
-  linkType: hard
-
-"@types/supertest@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
-  dependencies:
-    "@types/methods": "npm:^1.1.4"
-    "@types/superagent": "npm:^8.1.0"
-  checksum: 10c0/a2080f870154b09db123864a484fb633bc9e2a0f7294a194388df4c7effe5af9de36d5a5ebf819f72b404fa47b5e813c47d5a3a51354251fd2fa8589bfb64f2c
   languageName: node
   linkType: hard
 
@@ -607,20 +553,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.0":
-  version: 2.0.6
-  resolution: "asap@npm:2.0.6"
-  checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
-  languageName: node
-  linkType: hard
-
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
-  languageName: node
-  linkType: hard
-
 "atomic-sleep@npm:^1.0.0":
   version: 1.0.0
   resolution: "atomic-sleep@npm:1.0.0"
@@ -734,22 +666,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: "npm:~1.0.0"
-  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
-"component-emitter@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "component-emitter@npm:1.3.1"
-  checksum: 10c0/e4900b1b790b5e76b8d71b328da41482118c0f3523a516a41be598dc2785a07fd721098d9bf6e22d89b19f4fa4e1025160dc00317ea111633a3e4f75c2b86032
-  languageName: node
-  linkType: hard
-
 "content-disposition@npm:^1.0.0":
   version: 1.0.1
   resolution: "content-disposition@npm:1.0.1"
@@ -764,7 +680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:^1.2.1, cookie-signature@npm:^1.2.2":
+"cookie-signature@npm:^1.2.1":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
   checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
@@ -785,13 +701,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookiejar@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "cookiejar@npm:2.1.4"
-  checksum: 10c0/2dae55611c6e1678f34d93984cbd4bda58f4fe3e5247cc4993f4a305cd19c913bbaf325086ed952e892108115073a747596453d3dc1c34947f47f731818b8ad1
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -803,7 +712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -822,13 +731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
-  languageName: node
-  linkType: hard
-
 "depd@npm:^2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
@@ -840,16 +742,6 @@ __metadata:
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
-  languageName: node
-  linkType: hard
-
-"dezalgo@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "dezalgo@npm:1.0.4"
-  dependencies:
-    asap: "npm:^2.0.0"
-    wrappy: "npm:1"
-  checksum: 10c0/8a870ed42eade9a397e6141fe5c025148a59ed52f1f28b1db5de216b4d57f0af7a257070c3af7ce3d5508c1ce9dd5009028a76f4b2cc9370dc56551d2355fad8
   languageName: node
   linkType: hard
 
@@ -905,18 +797,6 @@ __metadata:
   dependencies:
     es-errors: "npm:^1.3.0"
   checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
   languageName: node
   linkType: hard
 
@@ -1187,13 +1067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1"
-  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
-  languageName: node
-  linkType: hard
-
 "fast-uri@npm:^3.0.0, fast-uri@npm:^3.0.1":
   version: 3.1.0
   resolution: "fast-uri@npm:3.1.0"
@@ -1306,30 +1179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
-  languageName: node
-  linkType: hard
-
-"formidable@npm:^3.5.4":
-  version: 3.5.4
-  resolution: "formidable@npm:3.5.4"
-  dependencies:
-    "@paralleldrive/cuid2": "npm:^2.2.2"
-    dezalgo: "npm:^1.0.4"
-    once: "npm:^1.4.0"
-  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
-  languageName: node
-  linkType: hard
-
 "forwarded@npm:0.2.0":
   version: 0.2.0
   resolution: "forwarded@npm:0.2.0"
@@ -1360,7 +1209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
@@ -1422,19 +1271,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+"has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
   checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2"
-  dependencies:
-    has-symbols: "npm:^1.0.3"
-  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
   languageName: node
   linkType: hard
 
@@ -1724,33 +1564,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"methods@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "methods@npm:1.1.2"
-  checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
-  languageName: node
-  linkType: hard
-
 "mime-db@npm:^1.54.0":
   version: 1.54.0
   resolution: "mime-db@npm:1.54.0"
   checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.12":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: "npm:1.52.0"
-  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -1760,15 +1577,6 @@ __metadata:
   dependencies:
     mime-db: "npm:^1.54.0"
   checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
-  languageName: node
-  linkType: hard
-
-"mime@npm:2.6.0":
-  version: 2.6.0
-  resolution: "mime@npm:2.6.0"
-  bin:
-    mime: cli.js
-  checksum: 10c0/a7f2589900d9c16e3bdf7672d16a6274df903da958c1643c9c45771f0478f3846dcb1097f31eb9178452570271361e2149310931ec705c037210fc69639c8e6c
   languageName: node
   linkType: hard
 
@@ -2470,34 +2278,6 @@ __metadata:
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
   checksum: 10c0/fbd9aecc2621364384d157f7e59426f4bfd385e8b424b5aaa79c83a6f5a1c8fd2e4e3289e95de1eb3511cb96bb333d6281a9919fafce760e4edb35b2cd2facab
-  languageName: node
-  linkType: hard
-
-"superagent@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "superagent@npm:10.3.0"
-  dependencies:
-    component-emitter: "npm:^1.3.1"
-    cookiejar: "npm:^2.1.4"
-    debug: "npm:^4.3.7"
-    fast-safe-stringify: "npm:^2.1.1"
-    form-data: "npm:^4.0.5"
-    formidable: "npm:^3.5.4"
-    methods: "npm:^1.1.2"
-    mime: "npm:2.6.0"
-    qs: "npm:^6.14.1"
-  checksum: 10c0/7792ec2ba3a877eb1db57ad9149bf0e108688a40af0e75084bdc4bba82604b7962248267159565be4f5ab8aa392f1285a08d2e5a8cb2c3b0a51932499caf6ee6
-  languageName: node
-  linkType: hard
-
-"supertest@npm:^7.2.2":
-  version: 7.2.2
-  resolution: "supertest@npm:7.2.2"
-  dependencies:
-    cookie-signature: "npm:^1.2.2"
-    methods: "npm:^1.1.2"
-    superagent: "npm:^10.3.0"
-  checksum: 10c0/9de987aefbec50c5dfac79ff699bbc23c89cdbfe59ede165309fb3cf00c306117b30c5059fe6f7085c7525aab315ac27c77a1dc6056b993c7e0bb154a56c2b78
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,48 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@babel/helper-string-parser@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-string-parser@npm:7.27.1"
-  checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
-  checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/parser@npm:7.29.0"
-  dependencies:
-    "@babel/types": "npm:^7.29.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/types@npm:7.29.0"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
-  languageName: node
-  linkType: hard
-
-"@bcoe/v8-coverage@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@bcoe/v8-coverage@npm:1.0.2"
-  checksum: 10c0/1eb1dc93cc17fb7abdcef21a6e7b867d6aa99a7ec88ec8207402b23d9083ab22a8011213f04b2cf26d535f1d22dc26139b7929e6c2134c254bd1e14ba5e678c3
-  languageName: node
-  linkType: hard
-
 "@datadog/pprof@npm:5.14.4":
   version: 5.14.4
   resolution: "@datadog/pprof@npm:5.14.4"
@@ -230,42 +188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
-  checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
-  languageName: node
-  linkType: hard
-
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
-  version: 1.5.5
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
-  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.31":
-  version: 0.3.31
-  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
-  languageName: node
-  linkType: hard
-
-"@napi-rs/wasm-runtime@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.2"
-  dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
-  peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/725c30ec9c480a8d0c1a6a4ce31dc6c830365d485e23ad560e143d1cb9db89a0c95fbb5b9d53c07121729817a3683db6f1ab65d7e4f38fa7482a11b15ef6c6fd
-  languageName: node
-  linkType: hard
-
 "@noble/hashes@npm:^1.1.5":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
@@ -299,13 +221,6 @@ __metadata:
   version: 4.0.0
   resolution: "@npmcli/redact@npm:4.0.0"
   checksum: 10c0/a1e9ba9c70a6b40e175bda2c3dd8cfdaf096e6b7f7a132c855c083c8dfe545c3237cd56702e2e6627a580b1d63373599d49a1192c4078a85bf47bbde824df31c
-  languageName: node
-  linkType: hard
-
-"@oxc-project/types@npm:=0.122.0":
-  version: 0.122.0
-  resolution: "@oxc-project/types@npm:0.122.0"
-  checksum: 10c0/2c64dd0db949426fd0c86d4f61eded5902e7b7b166356a825bd3a248aeaa29a495f78918f66ab78e99644b67bd7556096e2a8123cec74ca4141c604f424f4f74
   languageName: node
   linkType: hard
 
@@ -343,7 +258,6 @@ __metadata:
     "@types/supertest": "npm:^6.0.3"
     "@typescript-eslint/eslint-plugin": "npm:^8.58.0"
     "@typescript-eslint/parser": "npm:^8.58.0"
-    "@vitest/coverage-v8": "npm:^4.1.2"
     busboy: "npm:^1.6.0"
     debug: "npm:^4.4.3"
     eslint: "npm:^10.1.0"
@@ -360,7 +274,6 @@ __metadata:
     source-map: "npm:^0.7.6"
     supertest: "npm:^7.2.2"
     typescript: "npm:^5.9.3"
-    vitest: "npm:^4.1.2"
   peerDependencies:
     express: ^4.0.0 || ^5.0.0
     fastify: ^5.7.4
@@ -372,152 +285,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.12"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.12"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12"
-  dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.1"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/pluginutils@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.12"
-  checksum: 10c0/f785d1180ea4876bf6a6a67135822808d1c07f902409524ff1088779f7d5318f6e603d281fb107a5145c1ca54b7cabebd359629ec474ebbc2812f2cf53db4023
-  languageName: node
-  linkType: hard
-
-"@standard-schema/spec@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@standard-schema/spec@npm:1.1.0"
-  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
-  languageName: node
-  linkType: hard
-
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "@tybys/wasm-util@npm:0.10.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
-  languageName: node
-  linkType: hard
-
 "@types/busboy@npm:^1.5.4":
   version: 1.5.4
   resolution: "@types/busboy@npm:1.5.4"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/0bdd209069a445d5a71277e558978ec0db1b1a3d108335da96477d017177ae349c4d81d604db0bea19e3c99c10af2d60dbac20e36cef7cb7a517e5a4760738bd
-  languageName: node
-  linkType: hard
-
-"@types/chai@npm:^5.2.2":
-  version: 5.2.3
-  resolution: "@types/chai@npm:5.2.3"
-  dependencies:
-    "@types/deep-eql": "npm:*"
-    assertion-error: "npm:^2.0.1"
-  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
   languageName: node
   linkType: hard
 
@@ -537,13 +310,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/deep-eql@npm:*":
-  version: 4.0.2
-  resolution: "@types/deep-eql@npm:4.0.2"
-  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
-  languageName: node
-  linkType: hard
-
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -551,7 +317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -754,112 +520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/coverage-v8@npm:4.1.2"
-  dependencies:
-    "@bcoe/v8-coverage": "npm:^1.0.2"
-    "@vitest/utils": "npm:4.1.2"
-    ast-v8-to-istanbul: "npm:^1.0.0"
-    istanbul-lib-coverage: "npm:^3.2.2"
-    istanbul-lib-report: "npm:^3.0.1"
-    istanbul-reports: "npm:^3.2.0"
-    magicast: "npm:^0.5.2"
-    obug: "npm:^2.1.1"
-    std-env: "npm:^4.0.0-rc.1"
-    tinyrainbow: "npm:^3.1.0"
-  peerDependencies:
-    "@vitest/browser": 4.1.2
-    vitest: 4.1.2
-  peerDependenciesMeta:
-    "@vitest/browser":
-      optional: true
-  checksum: 10c0/2f4488efb34a5d9e3a70631ba263e153eecba8ec0da52cb874cdc674c88369061706572b9fc0c302376fd1de58aedc86a2f9f75e5a521084e31a1446c85f2c40
-  languageName: node
-  linkType: hard
-
-"@vitest/expect@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/expect@npm:4.1.2"
-  dependencies:
-    "@standard-schema/spec": "npm:^1.1.0"
-    "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.2"
-    "@vitest/utils": "npm:4.1.2"
-    chai: "npm:^6.2.2"
-    tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/e238c833b5555d31b074545807956d5e874a1ef725525ecc99f1885b71b230b2127d40d8d142a7253666b8565d5806723853e85e0e99265520ec7506fdc5890c
-  languageName: node
-  linkType: hard
-
-"@vitest/mocker@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/mocker@npm:4.1.2"
-  dependencies:
-    "@vitest/spy": "npm:4.1.2"
-    estree-walker: "npm:^3.0.3"
-    magic-string: "npm:^0.30.21"
-  peerDependencies:
-    msw: ^2.4.9
-    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    msw:
-      optional: true
-    vite:
-      optional: true
-  checksum: 10c0/f23094f3c7e1e5af42e6a468f0815c1ecdcab85cb3a56ab6f3f214a9808a40271467d4352cae972482b9738cc31c62c7312d8b0da227d6ea03d2b3aacb8d385f
-  languageName: node
-  linkType: hard
-
-"@vitest/pretty-format@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/pretty-format@npm:4.1.2"
-  dependencies:
-    tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/6f57519c707e6a3d1ff8630ca87ce78fda9bf7bb33f6e4a0c775a8b510f2a6cee109849e2cdb736b0280681c567bd03e4cff724cbf0962950c9ff81377f0b2bc
-  languageName: node
-  linkType: hard
-
-"@vitest/runner@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/runner@npm:4.1.2"
-  dependencies:
-    "@vitest/utils": "npm:4.1.2"
-    pathe: "npm:^2.0.3"
-  checksum: 10c0/35654a87bd27983443adc24d68529d624f7d70e0386176741dc5bcc4188b86a70af2c512405d7e97aa45c16d83e1c8566c1f99c8440430f95557275f18612d21
-  languageName: node
-  linkType: hard
-
-"@vitest/snapshot@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/snapshot@npm:4.1.2"
-  dependencies:
-    "@vitest/pretty-format": "npm:4.1.2"
-    "@vitest/utils": "npm:4.1.2"
-    magic-string: "npm:^0.30.21"
-    pathe: "npm:^2.0.3"
-  checksum: 10c0/6d20e92386937afddbc81344211e554b83a559e20fb10c1deb0b1c3532994dc9fc62d816706ac835bdb737eb1ab02e9c0bc9de80dd8316060e1e0aaa447ba48f
-  languageName: node
-  linkType: hard
-
-"@vitest/spy@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/spy@npm:4.1.2"
-  checksum: 10c0/2b5888d536d3e2083c5f8939763e6d780c2c03cc60e1ab45f9d04eacf14467acb9724cae1c4778e4c06426d49d04517e190122882953054a4b13fda44780bb14
-  languageName: node
-  linkType: hard
-
-"@vitest/utils@npm:4.1.2":
-  version: 4.1.2
-  resolution: "@vitest/utils@npm:4.1.2"
-  dependencies:
-    "@vitest/pretty-format": "npm:4.1.2"
-    convert-source-map: "npm:^2.0.0"
-    tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/d96475e0703b6e5208c6c0f570c1235278cbac3f3913a9aa4203a3e617c9eaca85a184bfd5d13cf366b84754df787ab8bc85242c5e0c63105ee7176c186a2136
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -951,24 +611,6 @@ __metadata:
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
-  languageName: node
-  linkType: hard
-
-"assertion-error@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "assertion-error@npm:2.0.1"
-  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
-  languageName: node
-  linkType: hard
-
-"ast-v8-to-istanbul@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "ast-v8-to-istanbul@npm:1.0.0"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.31"
-    estree-walker: "npm:^3.0.3"
-    js-tokens: "npm:^10.0.0"
-  checksum: 10c0/35e57b754ba63287358094d4f7ae8de2de27286fb4e76a1fbf28b2e67e3b670b59c3f511882473d0fd2cdbaa260062e3cd4f216b724c70032e2b09e5cebbd618
   languageName: node
   linkType: hard
 
@@ -1085,13 +727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "chai@npm:6.2.2"
-  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
-  languageName: node
-  linkType: hard
-
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
@@ -1126,13 +761,6 @@ __metadata:
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
-  languageName: node
-  linkType: hard
-
-"convert-source-map@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "convert-source-map@npm:2.0.0"
-  checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
   languageName: node
   linkType: hard
 
@@ -1215,13 +843,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3":
-  version: 2.1.2
-  resolution: "detect-libc@npm:2.1.2"
-  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
-  languageName: node
-  linkType: hard
-
 "dezalgo@npm:^1.0.4":
   version: 1.0.4
   resolution: "dezalgo@npm:1.0.4"
@@ -1275,13 +896,6 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
-  languageName: node
-  linkType: hard
-
-"es-module-lexer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "es-module-lexer@npm:2.0.0"
-  checksum: 10c0/ae78dbbd43035a4b972c46cfb6877e374ea290adfc62bc2f5a083fea242c0b2baaab25c5886af86be55f092f4a326741cb94334cd3c478c383fdc8a9ec5ff817
   languageName: node
   linkType: hard
 
@@ -1458,15 +1072,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "estree-walker@npm:3.0.3"
-  dependencies:
-    "@types/estree": "npm:^1.0.0"
-  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
-  languageName: node
-  linkType: hard
-
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -1478,13 +1083,6 @@ __metadata:
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
-  languageName: node
-  linkType: hard
-
-"expect-type@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "expect-type@npm:1.3.0"
-  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -1755,25 +1353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.3":
-  version: 2.3.3
-  resolution: "fsevents@npm:2.3.3"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
-  version: 2.3.3
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
 "function-bind@npm:^1.1.2":
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
@@ -1843,13 +1422,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "has-flag@npm:4.0.0"
-  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
 "has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
@@ -1872,13 +1444,6 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-  languageName: node
-  linkType: hard
-
-"html-escaper@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "html-escaper@npm:2.0.2"
-  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
@@ -2026,47 +1591,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "istanbul-lib-coverage@npm:3.2.2"
-  checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "istanbul-lib-report@npm:3.0.1"
-  dependencies:
-    istanbul-lib-coverage: "npm:^3.0.0"
-    make-dir: "npm:^4.0.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/84323afb14392de8b6a5714bd7e9af845cfbd56cfe71ed276cda2f5f1201aea673c7111901227ee33e68e4364e288d73861eb2ed48f6679d1e69a43b6d9b3ba7
-  languageName: node
-  linkType: hard
-
-"istanbul-reports@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "istanbul-reports@npm:3.2.0"
-  dependencies:
-    html-escaper: "npm:^2.0.0"
-    istanbul-lib-report: "npm:^3.0.0"
-  checksum: 10c0/d596317cfd9c22e1394f22a8d8ba0303d2074fe2e971887b32d870e4b33f8464b10f8ccbe6847808f7db485f084eba09e6c2ed706b3a978e4b52f07085b8f9bc
-  languageName: node
-  linkType: hard
-
 "jackspeak@npm:^4.2.3":
   version: 4.2.3
   resolution: "jackspeak@npm:4.2.3"
   dependencies:
     "@isaacs/cliui": "npm:^9.0.0"
   checksum: 10c0/b5c0c414f1607c2aa0597f4bf2c03b8443897fccd5fd3c2b3e4f77d556b2bc7c3d3413828ba91e0789f6fb40ad90242f7f89fb20aee9e9d705bc1681f7564f67
-  languageName: node
-  linkType: hard
-
-"js-tokens@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "js-tokens@npm:10.0.0"
-  checksum: 10c0/a93498747812ba3e0c8626f95f75ab29319f2a13613a0de9e610700405760931624433a0de59eb7c27ff8836e526768fb20783861b86ef89be96676f2c996b64
   languageName: node
   linkType: hard
 
@@ -2137,126 +1667,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-android-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-android-arm64@npm:1.32.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-darwin-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-darwin-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-x64@npm:1.32.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss-freebsd-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-x64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-x64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-win32-arm64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-win32-x64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss@npm:1.32.0"
-  dependencies:
-    detect-libc: "npm:^2.0.3"
-    lightningcss-android-arm64: "npm:1.32.0"
-    lightningcss-darwin-arm64: "npm:1.32.0"
-    lightningcss-darwin-x64: "npm:1.32.0"
-    lightningcss-freebsd-x64: "npm:1.32.0"
-    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
-    lightningcss-linux-arm64-gnu: "npm:1.32.0"
-    lightningcss-linux-arm64-musl: "npm:1.32.0"
-    lightningcss-linux-x64-gnu: "npm:1.32.0"
-    lightningcss-linux-x64-musl: "npm:1.32.0"
-    lightningcss-win32-arm64-msvc: "npm:1.32.0"
-    lightningcss-win32-x64-msvc: "npm:1.32.0"
-  dependenciesMeta:
-    lightningcss-android-arm64:
-      optional: true
-    lightningcss-darwin-arm64:
-      optional: true
-    lightningcss-darwin-x64:
-      optional: true
-    lightningcss-freebsd-x64:
-      optional: true
-    lightningcss-linux-arm-gnueabihf:
-      optional: true
-    lightningcss-linux-arm64-gnu:
-      optional: true
-    lightningcss-linux-arm64-musl:
-      optional: true
-    lightningcss-linux-x64-gnu:
-      optional: true
-    lightningcss-linux-x64-musl:
-      optional: true
-    lightningcss-win32-arm64-msvc:
-      optional: true
-    lightningcss-win32-x64-msvc:
-      optional: true
-  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
-  languageName: node
-  linkType: hard
-
 "locate-path@npm:^6.0.0":
   version: 6.0.0
   resolution: "locate-path@npm:6.0.0"
@@ -2270,35 +1680,6 @@ __metadata:
   version: 11.2.7
   resolution: "lru-cache@npm:11.2.7"
   checksum: 10c0/549cdb59488baa617135fc12159cafb1a97f91079f35093bb3bcad72e849fc64ace636d244212c181dfdf1a99bbfa90757ff303f98561958ee4d0f885d9bd5f7
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.21":
-  version: 0.30.21
-  resolution: "magic-string@npm:0.30.21"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
-  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
-  languageName: node
-  linkType: hard
-
-"magicast@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "magicast@npm:0.5.2"
-  dependencies:
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/924af677643c5a0a7d6cdb3247c0eb96fa7611b2ba6a5e720d35d81c503d3d9f5948eb5227f80f90f82ea3e7d38cffd10bb988f3fc09020db428e14f26e960d7
-  languageName: node
-  linkType: hard
-
-"make-dir@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "make-dir@npm:4.0.0"
-  dependencies:
-    semver: "npm:^7.5.3"
-  checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
   languageName: node
   linkType: hard
 
@@ -2483,15 +1864,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -2552,13 +1924,6 @@ __metadata:
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
-  languageName: node
-  linkType: hard
-
-"obug@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "obug@npm:2.1.1"
-  checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
   languageName: node
   linkType: hard
 
@@ -2673,20 +2038,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "pathe@npm:2.0.3"
-  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "picocolors@npm:1.1.1"
-  checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
-  languageName: node
-  linkType: hard
-
 "picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
@@ -2737,17 +2088,6 @@ __metadata:
   bin:
     pinst: bin.js
   checksum: 10c0/abb1ed62ea2acb2207a7a860715bdb26ecbde74ede8fad5f6200194f3e22db25e2b7a49af05e5cc7fc05384709c651e0000323f0077d7239060c4b68c8acd428
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
   languageName: node
   linkType: hard
 
@@ -2898,64 +2238,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "rolldown@npm:1.0.0-rc.12"
-  dependencies:
-    "@oxc-project/types": "npm:=0.122.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.12"
-  dependenciesMeta:
-    "@rolldown/binding-android-arm64":
-      optional: true
-    "@rolldown/binding-darwin-arm64":
-      optional: true
-    "@rolldown/binding-darwin-x64":
-      optional: true
-    "@rolldown/binding-freebsd-x64":
-      optional: true
-    "@rolldown/binding-linux-arm-gnueabihf":
-      optional: true
-    "@rolldown/binding-linux-arm64-gnu":
-      optional: true
-    "@rolldown/binding-linux-arm64-musl":
-      optional: true
-    "@rolldown/binding-linux-ppc64-gnu":
-      optional: true
-    "@rolldown/binding-linux-s390x-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-musl":
-      optional: true
-    "@rolldown/binding-openharmony-arm64":
-      optional: true
-    "@rolldown/binding-wasm32-wasi":
-      optional: true
-    "@rolldown/binding-win32-arm64-msvc":
-      optional: true
-    "@rolldown/binding-win32-x64-msvc":
-      optional: true
-  bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/0c4e5e3cdcdddce282cb2d84e1c98d6ad8d4e452d5c1402e498b35ec1060026e552dd783efc9f4ba876d7c0863b5973edc79b6a546f565e9832dc1077ec18c2c
-  languageName: node
-  linkType: hard
-
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"
@@ -2999,7 +2281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.6.0, semver@npm:^7.7.3":
+"semver@npm:^7.3.5, semver@npm:^7.6.0, semver@npm:^7.7.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -3117,13 +2399,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"siginfo@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "siginfo@npm:2.0.0"
-  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
-  languageName: node
-  linkType: hard
-
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -3161,13 +2436,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "source-map-js@npm:1.2.1"
-  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
-  languageName: node
-  linkType: hard
-
 "source-map@npm:*, source-map@npm:^0.7.4, source-map@npm:^0.7.6":
   version: 0.7.6
   resolution: "source-map@npm:0.7.6"
@@ -3191,24 +2459,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stackback@npm:0.0.2":
-  version: 0.0.2
-  resolution: "stackback@npm:0.0.2"
-  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
-  languageName: node
-  linkType: hard
-
 "statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
-  languageName: node
-  linkType: hard
-
-"std-env@npm:^4.0.0-rc.1":
-  version: 4.0.0
-  resolution: "std-env@npm:4.0.0"
-  checksum: 10c0/63b1716eae27947adde49e21b7225a0f75fb2c3d410273ae9de8333c07c7d5fc7a0628ae4c8af6b4b49b4274ed46c2bf118ed69b64f1261c9d8213d76ed1c16c
   languageName: node
   linkType: hard
 
@@ -3247,15 +2501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "supports-color@npm:7.2.0"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
-  languageName: node
-  linkType: hard
-
 "synckit@npm:^0.11.12":
   version: 0.11.12
   resolution: "synckit@npm:0.11.12"
@@ -3287,20 +2532,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinybench@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "tinybench@npm:2.9.0"
-  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
-  languageName: node
-  linkType: hard
-
-"tinyexec@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "tinyexec@npm:1.0.2"
-  checksum: 10c0/1261a8e34c9b539a9aae3b7f0bb5372045ff28ee1eba035a2a059e532198fe1a182ec61ac60fa0b4a4129f0c4c4b1d2d57355b5cb9aa2d17ac9454ecace502ee
-  languageName: node
-  linkType: hard
-
 "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -3308,13 +2539,6 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
-  languageName: node
-  linkType: hard
-
-"tinyrainbow@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "tinyrainbow@npm:3.1.0"
-  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -3338,13 +2562,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.4.0":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -3418,125 +2635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.0.3
-  resolution: "vite@npm:8.0.3"
-  dependencies:
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.8"
-    rolldown: "npm:1.0.0-rc.12"
-    tinyglobby: "npm:^0.2.15"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.0
-    esbuild: ^0.27.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/bed9520358080393a02fe22565b3309b4b3b8f916afe4c97577528f3efb05c1bf4b29f7b552179bc5b3938629e50fbd316231727457411dbc96648fa5c9d14bf
-  languageName: node
-  linkType: hard
-
-"vitest@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "vitest@npm:4.1.2"
-  dependencies:
-    "@vitest/expect": "npm:4.1.2"
-    "@vitest/mocker": "npm:4.1.2"
-    "@vitest/pretty-format": "npm:4.1.2"
-    "@vitest/runner": "npm:4.1.2"
-    "@vitest/snapshot": "npm:4.1.2"
-    "@vitest/spy": "npm:4.1.2"
-    "@vitest/utils": "npm:4.1.2"
-    es-module-lexer: "npm:^2.0.0"
-    expect-type: "npm:^1.3.0"
-    magic-string: "npm:^0.30.21"
-    obug: "npm:^2.1.1"
-    pathe: "npm:^2.0.3"
-    picomatch: "npm:^4.0.3"
-    std-env: "npm:^4.0.0-rc.1"
-    tinybench: "npm:^2.9.0"
-    tinyexec: "npm:^1.0.2"
-    tinyglobby: "npm:^0.2.15"
-    tinyrainbow: "npm:^3.1.0"
-    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
-    why-is-node-running: "npm:^2.3.0"
-  peerDependencies:
-    "@edge-runtime/vm": "*"
-    "@opentelemetry/api": ^1.9.0
-    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.2
-    "@vitest/browser-preview": 4.1.2
-    "@vitest/browser-webdriverio": 4.1.2
-    "@vitest/ui": 4.1.2
-    happy-dom: "*"
-    jsdom: "*"
-    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    "@edge-runtime/vm":
-      optional: true
-    "@opentelemetry/api":
-      optional: true
-    "@types/node":
-      optional: true
-    "@vitest/browser-playwright":
-      optional: true
-    "@vitest/browser-preview":
-      optional: true
-    "@vitest/browser-webdriverio":
-      optional: true
-    "@vitest/ui":
-      optional: true
-    happy-dom:
-      optional: true
-    jsdom:
-      optional: true
-    vite:
-      optional: false
-  bin:
-    vitest: vitest.mjs
-  checksum: 10c0/061fdd0319ba533c926b139b9377a7dbf91e63d815d86fe318a207bd19842b74ca6f6402ea61b26ed9d2924306bdb4d0b13f69c29e2a2a89b3b67602bcccb54c
-  languageName: node
-  linkType: hard
-
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -3556,18 +2654,6 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
-  languageName: node
-  linkType: hard
-
-"why-is-node-running@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "why-is-node-running@npm:2.3.0"
-  dependencies:
-    siginfo: "npm:^2.0.0"
-    stackback: "npm:0.0.2"
-  bin:
-    why-is-node-running: cli.js
-  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces 
- `vitest` with `node:test`
-  `supertest` with `http.createServer(app)` + Node's built-in fetch.

For `vitest`, tests here are relatively simple and I think we can get away without a fancy test framework. 

Before:
```
yarn info --recursive --name-only | sort -u | wc -l
     375
```

After:
```
yarn info --recursive --name-only | sort -u | wc -l
     265
```

If we want to get much lower than this we'd need to drop or rework the Express/Fastify integration tests, but I don't think that is a good idea.