### PR TITLE
chore: add yarn npm release age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
 enableScripts: false
 nodeLinker: node-modules
+npmMinimalAgeGate: 4320


### PR DESCRIPTION
## Summary

- audit root package-manager supply-chain hardening settings
- add Yarn npm package age gate via `npmMinimalAgeGate: 4320`
- leave lifecycle scripts disabled via existing `enableScripts: false`

## Audit

| # | Check | Status | Detail |
|---|---|---|---|
| 0 | Package manager | yarn | version: 4.13.0 (pinned: 4.13.0) |
| 1 | Tool version >= threshold | PASS | 4.13.0 vs required 4.0.0 |
| 2 | Scripts disabled | PASS | `.yarnrc.yml`: `enableScripts: false` |
| 3 | Git deps blocked | N/A | no git URL dependencies found; Yarn 4.13.0 rejects `approvedGitRepositories` |
| 4 | Min release age >= 3 days | PASS | `.yarnrc.yml`: `npmMinimalAgeGate: 4320` |

## Verification

- `corepack yarn config get npmMinimalAgeGate` -> `4320`
- `corepack yarn install --immutable` passed with existing peer dependency warning
- `git diff --check` passed