### PR TITLE
chore: Update release-please workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    environment: 'NPM Trusted Publishing'
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: 'false'
+      - name: Setup .npmrc file to publish to npm
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '26.2.0'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install modules
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Publish to npm
+        run: npm publish
+      - name: Publish GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    outputs:
-      release_created: ${{ steps.rp.outputs.release_created }}
-      tag_name: ${{ steps.rp.outputs.tag_name }}
-      sha: ${{ steps.rp.outputs.sha }}
-      version: ${{ steps.rp.outputs.version }}
     steps:
       - id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
@@ -31,37 +26,3 @@ jobs:
           token: ${{ steps.get-github-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  publish:
-    name: Publish npm package
-    needs: release-please
-    runs-on: ubuntu-latest
-    if: needs.release-please.outputs.release_created == 'true'
-    environment: 'NPM Trusted Publishing'
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.release-please.outputs.sha }}
-          persist-credentials: 'false'
-      - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '26.2.0'
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false
-      - name: Enable corepack
-        run: corepack enable
-      - name: Install modules
-        run: yarn
-      - name: Build
-        run: yarn build
-      - name: Publish to npm
-        run: npm publish
-      - name: Publish GitHub release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release edit "$TAG_NAME" --draft=false


### PR DESCRIPTION
This splits out the release workflow into two stages:

1. release-please creates a tag with changelog (triggered on PR merge)
2. publish actually pushes the release to NPM (triggered on `v*` tag creation)