### PR TITLE
ci: Only create security patches for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
-  "extends": ["github>grafana/grafana-renovate-config//presets/base"],
-  "packageRules": [
-    {
-      "matchManagers": ["npm"],
-      "rangeStrategy": "bump"
-    }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "security:only-security-updates"
   ]
 }


### PR DESCRIPTION
Configure renovate to only create security related patches. Follows a similar pattern to https://github.com/grafana/pyroscope-java/pull/308.