### PR TITLE
fix(security): pin path-to-regexp to 8.4.0 (CVE-2026-4926, CVE-2026-4923)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "resolutions": {
     "brace-expansion": "^5.0.6",
     "flatted": "^3.4.2",
+    "path-to-regexp": "8.4.0",
     "picomatch": "^4.0.4"
   },
   "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,10 +1839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^8.0.0":
-  version: 8.3.0
-  resolution: "path-to-regexp@npm:8.3.0"
-  checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
+"path-to-regexp@npm:8.4.0":
+  version: 8.4.0
+  resolution: "path-to-regexp@npm:8.4.0"
+  checksum: 10c0/171a540aed2a5dff3da6e7584f263ae65d868daea382ea3bd1ddeb828912661133d5a94fce83bd3125f0799df8dfd4924b270e2987a31930901cfd94ae164b45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security Fix

Pins the transitive dependency `path-to-regexp` to `8.4.0` via the `resolutions` field in `package.json` to remediate two CVEs.

### CVEs Fixed

| CVE | Severity | CVSS | SLO Status |
|-----|----------|------|-----------|
| CVE-2026-4926 | HIGH | 7.5 | **-26 days overdue** — Denial of Service via crafted regular expressions |
| CVE-2026-4923 | MEDIUM | 5.9 | 4 days remaining — Denial of Service via paths with multiple wildcards |

### Root Cause

`path-to-regexp` is a transitive dependency pulled in by `express` (devDependency / peerDependency). The vulnerable version `8.3.0` is resolved by semver ranges already in use, so no direct dependency change is needed — only a `resolutions` pin.

### Change

```json
"resolutions": {
  "path-to-regexp": "8.4.0"
}
```

### Verification

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ (27/27 tests pass, Node 20.x locally)

CI covers Node 20/22/24/26 matrix.

### Merge Note

A companion PR fixes `fast-uri` CVEs in the same files (`package.json` + `yarn.lock`). Whichever merges second will need a rebase to regenerate the lockfile cleanly.