### PR TITLE
fix(security): pin fast-uri to 3.1.2 (CVE-2026-6322, CVE-2026-6321)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "resolutions": {
     "brace-expansion": "^5.0.6",
+    "fast-uri": "3.1.2",
     "flatted": "^3.4.2",
     "path-to-regexp": "8.4.0",
     "picomatch": "^4.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,10 +1067,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.0, fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security Fix

Pins the transitive dependency `fast-uri` to `3.1.2` via the `resolutions` field in `package.json` to remediate two HIGH CVEs.

### CVEs Fixed

| CVE | Severity | CVSS | SLO Status |
|-----|----------|------|-----------|
| CVE-2026-6322 | HIGH | 7.5 | **-2 days overdue** — Host confusion via percent-encoded authority delimiters |
| CVE-2026-6321 | HIGH | 7.5 | **-2 days overdue** — Path traversal via percent-encoded dot segments |

### Root Cause

`fast-uri` is a transitive dependency pulled in by `fastify`, `ajv`, and related packages (all devDependencies / peerDependencies). The vulnerable version `3.1.0` is resolved by semver ranges `^3.0.0` / `^3.0.1`. A `resolutions` pin forces the safe version without changing direct dependencies.

### Change

```json
"resolutions": {
  "fast-uri": "3.1.2"
}
```

### Verification

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ (27/27 tests pass, Node 20.x locally)

CI covers Node 20/22/24/26 matrix.

### Merge Note

A companion PR fixes `path-to-regexp` CVEs in the same files (`package.json` + `yarn.lock`). Whichever merges second will need a rebase to regenerate the lockfile cleanly.