### PR TITLE
fix(config): validate label characters in Pyroscope config

### DIFF
--- a/src/utils/check-pyroscope-config.ts
+++ b/src/utils/check-pyroscope-config.ts
@@ -4,6 +4,9 @@ import {
   PyroscopeWallConfig,
 } from '../pyroscope-config.js';
 
+const INVALID_LABEL_CHARACTERS = ['{', '}', ',', '='] as const;
+const INVALID_LABEL_CHARACTERS_MESSAGE = "'{', '}', ',', or '=' characters";
+
 export function checkPyroscopeConfig(
   config: unknown
 ): asserts config is PyroscopeConfig {
@@ -15,7 +18,11 @@ export function checkPyroscopeConfig(
 
   if (!hasValidApplicationName(config)) {
     errors.push('Expecting a config with string appName');
+  } else {
+    validateApplicationName(config, errors);
   }
+
+  validateTags(config, errors);
 
   if (!hasValidAuthToken(config)) {
     errors.push('Expecting a config with string auth token');
@@ -49,6 +56,64 @@ function hasValidApplicationName(
     (config as Partial<PyroscopeConfig>).appName === undefined ||
     typeof (config as Partial<PyroscopeConfig>).appName === 'string'
   );
+}
+
+function validateApplicationName(
+  config: Record<string | symbol, unknown>,
+  errors: string[]
+): void {
+  const appName: string | undefined = (config as Partial<PyroscopeConfig>)
+    .appName;
+
+  if (appName === undefined) {
+    return;
+  }
+
+  if (hasInvalidLabelCharacters(appName)) {
+    errors.push(`appName must not contain ${INVALID_LABEL_CHARACTERS_MESSAGE}`);
+  }
+}
+
+function validateTags(
+  config: Record<string | symbol, unknown>,
+  errors: string[]
+): void {
+  const tags: unknown = (config as Partial<PyroscopeConfig>).tags;
+
+  if (tags === undefined) {
+    return;
+  }
+
+  if (!isObject(tags)) {
+    errors.push('Expecting a config with object tags');
+    return;
+  }
+
+  for (const [tagKey, tagValue] of Object.entries(tags)) {
+    if (hasInvalidLabelCharacters(tagKey)) {
+      errors.push(
+        `tag key "${tagKey}" must not contain ${INVALID_LABEL_CHARACTERS_MESSAGE}`
+      );
+    }
+
+    if (typeof tagValue === 'string' && hasInvalidLabelCharacters(tagValue)) {
+      errors.push(
+        `tag value for "${tagKey}" must not contain ${INVALID_LABEL_CHARACTERS_MESSAGE}`
+      );
+    } else if (typeof tagValue !== 'number' && typeof tagValue !== 'string') {
+      errors.push(`tag value for "${tagKey}" must be a string or number`);
+    }
+  }
+}
+
+function hasInvalidLabelCharacters(value: string): boolean {
+  for (const character of INVALID_LABEL_CHARACTERS) {
+    if (value.includes(character)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function hasValidAuthToken(config: Record<string | symbol, unknown>): boolean {

--- a/src/utils/check-pyroscope-config.ts
+++ b/src/utils/check-pyroscope-config.ts
@@ -98,10 +98,12 @@ function validateTags(
 
     if (typeof tagValue === 'string' && hasInvalidLabelCharacters(tagValue)) {
       errors.push(
-        `tag value for "${tagKey}" must not contain ${INVALID_LABEL_CHARACTERS_MESSAGE}`
+        `tag value "${tagValue}" for key "${tagKey}" must not contain ${INVALID_LABEL_CHARACTERS_MESSAGE}`
       );
     } else if (typeof tagValue !== 'number' && typeof tagValue !== 'string') {
-      errors.push(`tag value for "${tagKey}" must be a string or number`);
+      errors.push(
+        `tag value "${String(tagValue)}" for key "${tagKey}" must be a string or number`
+      );
     }
   }
 }

--- a/test/check-pyroscope-config.test.ts
+++ b/test/check-pyroscope-config.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { checkPyroscopeConfig } from '../src/utils/check-pyroscope-config.js';
+
+const INVALID_CHARACTERS = ['{', '}', ',', '='];
+
+describe('checkPyroscopeConfig', () => {
+  it('accepts a valid config', () => {
+    assert.doesNotThrow(() =>
+      checkPyroscopeConfig({
+        appName: 'my-app',
+        tags: { region: 'us-east-1', replica: 3 },
+      })
+    );
+  });
+
+  for (const character of INVALID_CHARACTERS) {
+    it(`rejects appName containing "${character}"`, () => {
+      assert.throws(
+        () => checkPyroscopeConfig({ appName: `my${character}app` }),
+        /appName must not contain/
+      );
+    });
+
+    it(`rejects tag key containing "${character}"`, () => {
+      assert.throws(
+        () =>
+          checkPyroscopeConfig({
+            appName: 'my-app',
+            tags: { [`bad${character}key`]: 'value' },
+          }),
+        new RegExp(`tag key "bad\\${character}key" must not contain`)
+      );
+    });
+
+    it(`rejects tag value containing "${character}"`, () => {
+      assert.throws(
+        () =>
+          checkPyroscopeConfig({
+            appName: 'my-app',
+            tags: { key: `bad${character}value` },
+          }),
+        new RegExp(`tag value "bad\\${character}value" for key "key"`)
+      );
+    });
+  }
+
+  it('rejects a tag value that is not a string or number', () => {
+    assert.throws(
+      () =>
+        checkPyroscopeConfig({
+          appName: 'my-app',
+          tags: { key: true },
+        }),
+      /tag value "true" for key "key" must be a string or number/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Reject `appName` and tag keys/values that contain Prometheus label syntax characters (`{`, `}`, `,`, `=`) during config validation
- Keep existing tag type checks (string or number)

## Test plan
- [ ] Run `yarn test`
- [ ] Verify invalid `appName` / tag values produce clear validation errors at init time