### PR TITLE
feat: add stripFilenames and shortenPaths options to reduce profile size

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@datadog/pprof": "5.14.4",
     "debug": "^4.4.3",
     "p-limit": "^7.3.0",
+    "pprof-format": "^2.2.1",
     "regenerator-runtime": "^0.14.1",
     "source-map": "^0.7.6"
   },
@@ -63,7 +64,6 @@
     "fastify": "^5.8.5",
     "husky": "^9.1.7",
     "pinst": "^3.0.0",
-    "pprof-format": "^2.2.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,3 +1,5 @@
+import { StripFilenamesMode } from './pyroscope-config.js';
+
 export interface Environment {
   adhocServerAddress: string | undefined;
   appName: string | undefined;
@@ -9,4 +11,6 @@ export interface Environment {
   wallSamplingDurationMs: number | undefined;
   wallSamplingIntervalMicros: number | undefined;
   wallCollectCpuTime: boolean | undefined;
+  stripFilenames: StripFilenamesMode | undefined;
+  shortenPaths: boolean | undefined;
 }

--- a/src/pyroscope-api-exporter.ts
+++ b/src/pyroscope-api-exporter.ts
@@ -96,7 +96,10 @@ export class PyroscopeApiExporter implements ProfileExporter {
   private async buildUploadProfileFormData(
     profile: Profile
   ): Promise<FormData> {
-    const processedProfile: Profile = processProfile(profile);
+    const processedProfile: Profile = processProfile(profile, {
+      stripFilenames: this.config.stripFilenames,
+      shortenPaths: this.config.shortenPaths,
+    });
     const profileBuffer: Buffer = await encode(processedProfile);
     const arrayBuffer: Uint8Array<ArrayBuffer> =
       this.buildArrayBuffer(profileBuffer);

--- a/src/pyroscope-config.ts
+++ b/src/pyroscope-config.ts
@@ -15,7 +15,16 @@ export interface PyroscopeConfig {
   basicAuthUser?: string | undefined;
   basicAuthPassword?: string | undefined;
   tenantID?: string | undefined;
+  stripFilenames?: StripFilenamesMode | undefined;
+  shortenPaths?: boolean | undefined;
 }
+
+// 'all' removes the filename from every function, 'dependencies' only from
+// functions in files under node_modules. Function names generated for the
+// flame graph keep the file path either way; what is lost is the structured
+// filename field used to link frames to source code (e.g. the GitHub
+// integration in Grafana).
+export type StripFilenamesMode = 'all' | 'dependencies';
 
 export interface PyroscopeWallConfig {
   samplingDurationMs?: number | undefined;

--- a/src/utils/check-pyroscope-config.ts
+++ b/src/utils/check-pyroscope-config.ts
@@ -44,9 +44,39 @@ export function checkPyroscopeConfig(
     errors.push('Expecting a config with valid wall options');
   }
 
+  if (!hasValidStripFilenames(config)) {
+    errors.push(
+      "Expecting a config with stripFilenames set to 'all' or 'dependencies'"
+    );
+  }
+
+  if (!hasValidShortenPaths(config)) {
+    errors.push('Expecting a config with boolean shortenPaths');
+  }
+
   if (errors.length > 0) {
     throw new Error(`Invalid config:\n\n${errors.join('\n')}`);
   }
+}
+
+function hasValidStripFilenames(
+  config: Record<string | symbol, unknown>
+): boolean {
+  const stripFilenames = (config as Partial<PyroscopeConfig>).stripFilenames;
+
+  return (
+    stripFilenames === undefined ||
+    stripFilenames === 'all' ||
+    stripFilenames === 'dependencies'
+  );
+}
+
+function hasValidShortenPaths(
+  config: Record<string | symbol, unknown>
+): boolean {
+  const shortenPaths = (config as Partial<PyroscopeConfig>).shortenPaths;
+
+  return shortenPaths === undefined || typeof shortenPaths === 'boolean';
 }
 
 function hasValidApplicationName(

--- a/src/utils/get-env.ts
+++ b/src/utils/get-env.ts
@@ -1,4 +1,5 @@
 import { Environment } from '../environment.js';
+import { StripFilenamesMode } from '../pyroscope-config.js';
 
 export function getEnv(): Environment {
   return {
@@ -22,7 +23,17 @@ export function getEnv(): Environment {
     wallCollectCpuTime: parseBooleanEnv(
       process.env['PYROSCOPE_WALL_COLLECT_CPU_TIME']
     ),
+    stripFilenames: parseStripFilenamesEnv(
+      process.env['PYROSCOPE_STRIP_FILENAMES']
+    ),
+    shortenPaths: parseBooleanEnv(process.env['PYROSCOPE_SHORTEN_PATHS']),
   };
+}
+
+function parseStripFilenamesEnv(
+  envVal: string | undefined
+): StripFilenamesMode | undefined {
+  return envVal === 'all' || envVal === 'dependencies' ? envVal : undefined;
 }
 
 function parseNumericEnv(envVal: string | undefined) {

--- a/src/utils/process-config.ts
+++ b/src/utils/process-config.ts
@@ -28,6 +28,8 @@ export function processConfig(
     basicAuthUser: config.basicAuthUser,
     basicAuthPassword: config.basicAuthPassword,
     tenantID: config.tenantID,
+    stripFilenames: config.stripFilenames ?? env.stripFilenames,
+    shortenPaths: config.shortenPaths ?? env.shortenPaths,
   };
 
   return processedConfig;

--- a/src/utils/process-profile.ts
+++ b/src/utils/process-profile.ts
@@ -1,4 +1,9 @@
-import { Function as PprofFunction, Profile, StringTable } from 'pprof-format';
+import {
+  Function as PprofFunction,
+  Profile,
+  StringTable,
+  ValueType,
+} from 'pprof-format';
 
 import { StripFilenamesMode } from '../pyroscope-config.js';
 
@@ -111,13 +116,31 @@ function rebuildStringTable(profile: Profile): void {
   const remap = (index: number | bigint): number =>
     newTable.dedup(oldStrings[Number(index)] ?? '');
 
-  for (const valueType of profile.sampleType) {
+  // The serializer aliases objects (the heap profile's periodType is the same
+  // ValueType instance as its second sample type), and remapping an object
+  // twice resolves a new-table index against the old table, corrupting the
+  // string. Track visited objects so each is remapped exactly once.
+  const visited = new WeakSet<object>();
+  const remapValueType = (valueType: ValueType | undefined): void => {
+    if (valueType === undefined || visited.has(valueType)) {
+      return;
+    }
+    visited.add(valueType);
     valueType.type = remap(valueType.type);
     valueType.unit = remap(valueType.unit);
+  };
+
+  for (const valueType of profile.sampleType) {
+    remapValueType(valueType);
   }
+  remapValueType(profile.periodType);
 
   for (const sample of profile.sample) {
     for (const label of sample.label) {
+      if (visited.has(label)) {
+        continue;
+      }
+      visited.add(label);
       label.key = remap(label.key);
       label.str = remap(label.str);
       label.numUnit = remap(label.numUnit);
@@ -125,19 +148,22 @@ function rebuildStringTable(profile: Profile): void {
   }
 
   for (const mapping of profile.mapping) {
+    if (visited.has(mapping)) {
+      continue;
+    }
+    visited.add(mapping);
     mapping.filename = remap(mapping.filename);
     mapping.buildId = remap(mapping.buildId);
   }
 
   for (const contextFunction of profile.function) {
+    if (visited.has(contextFunction)) {
+      continue;
+    }
+    visited.add(contextFunction);
     contextFunction.name = remap(contextFunction.name);
     contextFunction.systemName = remap(contextFunction.systemName);
     contextFunction.filename = remap(contextFunction.filename);
-  }
-
-  if (profile.periodType !== undefined) {
-    profile.periodType.type = remap(profile.periodType.type);
-    profile.periodType.unit = remap(profile.periodType.unit);
   }
 
   profile.dropFrames = remap(profile.dropFrames);

--- a/src/utils/process-profile.ts
+++ b/src/utils/process-profile.ts
@@ -1,4 +1,6 @@
-import { Function as PprofFunction, Profile } from 'pprof-format';
+import { Function as PprofFunction, Profile, StringTable } from 'pprof-format';
+
+import { StripFilenamesMode } from '../pyroscope-config.js';
 
 const V8_NAME_TO_GOLANG_NAME_MAP: Record<string, string> = {
   objects: 'inuse_objects',
@@ -6,14 +8,31 @@ const V8_NAME_TO_GOLANG_NAME_MAP: Record<string, string> = {
   space: 'inuse_space',
 };
 
-export function processProfile(profile: Profile): Profile {
+const NODE_MODULES_SEGMENT = 'node_modules/';
+
+export interface ProcessProfileOptions {
+  stripFilenames?: StripFilenamesMode | undefined;
+  shortenPaths?: boolean | undefined;
+}
+
+export function processProfile(
+  profile: Profile,
+  options: ProcessProfileOptions = {}
+): Profile {
   adjustSampleNames(profile);
-  adjustCwdPaths(profile);
+  adjustCwdPaths(profile, options.shortenPaths ?? false);
+
+  if (options.stripFilenames !== undefined) {
+    stripFilenames(profile, options.stripFilenames);
+    rebuildStringTable(profile);
+  }
 
   return profile;
 }
 
-function adjustCwdPaths(profile: Profile): void {
+function adjustCwdPaths(profile: Profile, shortenPaths: boolean): void {
+  const cwd: string = process.cwd();
+
   for (const location of profile.location) {
     for (const line of location.line) {
       const functionId = Number(line.functionId);
@@ -32,16 +51,90 @@ function adjustCwdPaths(profile: Profile): void {
             Number(contextFunction.filename)
           ] as string;
 
-          const newName = `${fileName.replace(
-            process.cwd(),
-            '.'
-          )}:${functionName}:${line.line}`;
+          const displayPath: string =
+            (shortenPaths ? packageRelativePath(fileName) : undefined) ??
+            fileName.replace(cwd, '.');
+
+          const newName = `${displayPath}:${functionName}:${line.line}`;
 
           contextFunction.name = profile.stringTable.dedup(newName);
         }
       }
     }
   }
+}
+
+// For files vendored under node_modules, the path relative to the innermost
+// package is enough to identify the file, while the (potentially nested)
+// prefix is the biggest contributor to the profile's string table size.
+function packageRelativePath(fileName: string): string | undefined {
+  const index: number = fileName.lastIndexOf(NODE_MODULES_SEGMENT);
+
+  if (index === -1) {
+    return undefined;
+  }
+
+  return fileName.slice(index + NODE_MODULES_SEGMENT.length);
+}
+
+function stripFilenames(profile: Profile, mode: StripFilenamesMode): void {
+  for (const contextFunction of profile.function) {
+    if (mode === 'dependencies') {
+      const fileName: string | undefined =
+        profile.stringTable.strings[Number(contextFunction.filename)];
+
+      if (!fileName?.includes(NODE_MODULES_SEGMENT)) {
+        continue;
+      }
+    }
+
+    contextFunction.filename = 0;
+  }
+}
+
+// Stripped filenames leave their path strings unreferenced, but StringTable
+// only ever grows, so the profile has to be rewritten onto a fresh table for
+// the size reduction to materialize.
+function rebuildStringTable(profile: Profile): void {
+  const oldStrings: string[] = profile.stringTable.strings;
+  const newTable = new StringTable();
+  const remap = (index: number | bigint): number =>
+    newTable.dedup(oldStrings[Number(index)] ?? '');
+
+  for (const valueType of profile.sampleType) {
+    valueType.type = remap(valueType.type);
+    valueType.unit = remap(valueType.unit);
+  }
+
+  for (const sample of profile.sample) {
+    for (const label of sample.label) {
+      label.key = remap(label.key);
+      label.str = remap(label.str);
+      label.numUnit = remap(label.numUnit);
+    }
+  }
+
+  for (const mapping of profile.mapping) {
+    mapping.filename = remap(mapping.filename);
+    mapping.buildId = remap(mapping.buildId);
+  }
+
+  for (const contextFunction of profile.function) {
+    contextFunction.name = remap(contextFunction.name);
+    contextFunction.systemName = remap(contextFunction.systemName);
+    contextFunction.filename = remap(contextFunction.filename);
+  }
+
+  if (profile.periodType !== undefined) {
+    profile.periodType.type = remap(profile.periodType.type);
+    profile.periodType.unit = remap(profile.periodType.unit);
+  }
+
+  profile.dropFrames = remap(profile.dropFrames);
+  profile.keepFrames = remap(profile.keepFrames);
+  profile.comment = profile.comment.map(remap);
+  profile.defaultSampleType = remap(profile.defaultSampleType);
+  profile.stringTable = newTable;
 }
 
 function adjustSampleNames(profile: Profile): void {

--- a/src/utils/process-profile.ts
+++ b/src/utils/process-profile.ts
@@ -8,7 +8,9 @@ const V8_NAME_TO_GOLANG_NAME_MAP: Record<string, string> = {
   space: 'inuse_space',
 };
 
-const NODE_MODULES_SEGMENT = 'node_modules/';
+// V8 script names use native separators for CJS modules but URL-style forward
+// slashes for ESM (stripped file:// URLs), so on Windows both can appear.
+const NODE_MODULES_SEGMENTS = ['node_modules/', 'node_modules\\'] as const;
 
 export interface ProcessProfileOptions {
   stripFilenames?: StripFilenamesMode | undefined;
@@ -68,13 +70,21 @@ function adjustCwdPaths(profile: Profile, shortenPaths: boolean): void {
 // package is enough to identify the file, while the (potentially nested)
 // prefix is the biggest contributor to the profile's string table size.
 function packageRelativePath(fileName: string): string | undefined {
-  const index: number = fileName.lastIndexOf(NODE_MODULES_SEGMENT);
+  let start = -1;
 
-  if (index === -1) {
-    return undefined;
+  for (const segment of NODE_MODULES_SEGMENTS) {
+    const index: number = fileName.lastIndexOf(segment);
+
+    if (index !== -1) {
+      start = Math.max(start, index + segment.length);
+    }
   }
 
-  return fileName.slice(index + NODE_MODULES_SEGMENT.length);
+  return start === -1 ? undefined : fileName.slice(start);
+}
+
+function isDependencyPath(fileName: string): boolean {
+  return NODE_MODULES_SEGMENTS.some((segment) => fileName.includes(segment));
 }
 
 function stripFilenames(profile: Profile, mode: StripFilenamesMode): void {
@@ -83,7 +93,7 @@ function stripFilenames(profile: Profile, mode: StripFilenamesMode): void {
       const fileName: string | undefined =
         profile.stringTable.strings[Number(contextFunction.filename)];
 
-      if (!fileName?.includes(NODE_MODULES_SEGMENT)) {
+      if (fileName === undefined || !isDependencyPath(fileName)) {
         continue;
       }
     }

--- a/test/process-profile.test.ts
+++ b/test/process-profile.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  Function as PprofFunction,
+  Line,
+  Location,
+  Profile,
+  Sample,
+  StringTable,
+  ValueType,
+} from 'pprof-format';
+import { processProfile } from '../src/utils/process-profile.js';
+
+const APP_FILE = `${process.cwd()}/svc/handler.js`;
+const DEP_FILE = `${process.cwd()}/node_modules/@scope/pkg/node_modules/nested-dep/dist/index.js`;
+
+function buildProfile(): Profile {
+  const stringTable = new StringTable();
+  const str = (value: string): number => stringTable.dedup(value);
+
+  return new Profile({
+    sampleType: [new ValueType({ type: str('objects'), unit: str('count') })],
+    sample: [new Sample({ locationId: [2, 1], value: [10] })],
+    location: [
+      new Location({ id: 1, line: [new Line({ functionId: 1, line: 10 })] }),
+      new Location({ id: 2, line: [new Line({ functionId: 2, line: 42 })] }),
+    ],
+    function: [
+      new PprofFunction({
+        id: 1,
+        name: str('(anonymous)'),
+        systemName: str('(anonymous)'),
+        filename: str(APP_FILE),
+      }),
+      new PprofFunction({
+        id: 2,
+        name: str('handleRequest'),
+        systemName: str('handleRequest'),
+        filename: str(DEP_FILE),
+      }),
+    ],
+    stringTable,
+  });
+}
+
+function functionNames(profile: Profile): string[] {
+  return profile.function.map(
+    (fn) => profile.stringTable.strings[Number(fn.name)] as string
+  );
+}
+
+function fileName(profile: Profile, functionIndex: number): string {
+  return profile.stringTable.strings[
+    Number(profile.function[functionIndex]!.filename)
+  ] as string;
+}
+
+describe('processProfile', () => {
+  it('generates function names with cwd-relative paths by default', () => {
+    const profile = processProfile(buildProfile());
+
+    assert.deepEqual(functionNames(profile), [
+      './svc/handler.js:(anonymous):10',
+      './node_modules/@scope/pkg/node_modules/nested-dep/dist/index.js:handleRequest:42',
+    ]);
+    assert.equal(fileName(profile, 0), APP_FILE);
+    assert.equal(fileName(profile, 1), DEP_FILE);
+  });
+
+  it('uses package-relative paths with shortenPaths', () => {
+    const profile = processProfile(buildProfile(), { shortenPaths: true });
+
+    assert.deepEqual(functionNames(profile), [
+      './svc/handler.js:(anonymous):10',
+      'nested-dep/dist/index.js:handleRequest:42',
+    ]);
+    assert.equal(fileName(profile, 1), DEP_FILE);
+  });
+
+  it('removes every filename with stripFilenames: all', () => {
+    const profile = processProfile(buildProfile(), { stripFilenames: 'all' });
+
+    assert.equal(Number(profile.function[0]!.filename), 0);
+    assert.equal(Number(profile.function[1]!.filename), 0);
+
+    // display names still carry the path
+    assert.deepEqual(functionNames(profile), [
+      './svc/handler.js:(anonymous):10',
+      './node_modules/@scope/pkg/node_modules/nested-dep/dist/index.js:handleRequest:42',
+    ]);
+
+    // the orphaned path strings must not survive in the string table
+    assert.ok(!profile.stringTable.strings.includes(APP_FILE));
+    assert.ok(!profile.stringTable.strings.includes(DEP_FILE));
+  });
+
+  it('keeps first-party filenames with stripFilenames: dependencies', () => {
+    const profile = processProfile(buildProfile(), {
+      stripFilenames: 'dependencies',
+    });
+
+    assert.equal(fileName(profile, 0), APP_FILE);
+    assert.equal(Number(profile.function[1]!.filename), 0);
+    assert.ok(!profile.stringTable.strings.includes(DEP_FILE));
+  });
+
+  it('remaps sample type names when rebuilding the string table', () => {
+    const profile = processProfile(buildProfile(), { stripFilenames: 'all' });
+
+    const sampleType = profile.sampleType[0]!;
+    assert.equal(
+      profile.stringTable.strings[Number(sampleType.type)],
+      'inuse_objects'
+    );
+    assert.equal(
+      profile.stringTable.strings[Number(sampleType.unit)],
+      'count'
+    );
+    assert.equal(profile.stringTable.strings[0], '');
+  });
+});

--- a/test/process-profile.test.ts
+++ b/test/process-profile.test.ts
@@ -105,6 +105,42 @@ describe('processProfile', () => {
     assert.ok(!profile.stringTable.strings.includes(DEP_FILE));
   });
 
+  it('handles Windows path separators', () => {
+    const stringTable = new StringTable();
+    const str = (value: string): number => stringTable.dedup(value);
+    const winDepFile = 'C:\\app\\node_modules\\@scope\\pkg\\dist\\index.js';
+
+    const profile = new Profile({
+      sampleType: [
+        new ValueType({ type: str('objects'), unit: str('count') }),
+      ],
+      sample: [new Sample({ locationId: [1], value: [1] })],
+      location: [
+        new Location({ id: 1, line: [new Line({ functionId: 1, line: 7 })] }),
+      ],
+      function: [
+        new PprofFunction({
+          id: 1,
+          name: str('winFn'),
+          systemName: str('winFn'),
+          filename: str(winDepFile),
+        }),
+      ],
+      stringTable,
+    });
+
+    processProfile(profile, {
+      shortenPaths: true,
+      stripFilenames: 'dependencies',
+    });
+
+    assert.deepEqual(functionNames(profile), [
+      '@scope\\pkg\\dist\\index.js:winFn:7',
+    ]);
+    assert.equal(Number(profile.function[0]!.filename), 0);
+    assert.ok(!profile.stringTable.strings.includes(winDepFile));
+  });
+
   it('remaps sample type names when rebuilding the string table', () => {
     const profile = processProfile(buildProfile(), { stripFilenames: 'all' });
 

--- a/test/process-profile.test.ts
+++ b/test/process-profile.test.ts
@@ -141,6 +141,48 @@ describe('processProfile', () => {
     assert.ok(!profile.stringTable.strings.includes(winDepFile));
   });
 
+  it('remaps aliased value types only once when rebuilding', () => {
+    // The @datadog/pprof heap serializer uses the same ValueType instance for
+    // sampleType[1] and periodType; remapping it twice corrupted
+    // 'inuse_space' back to 'space'.
+    const stringTable = new StringTable();
+    const str = (value: string): number => stringTable.dedup(value);
+    const allocationValueType = new ValueType({
+      type: str('space'),
+      unit: str('bytes'),
+    });
+
+    const profile = new Profile({
+      sampleType: [
+        new ValueType({ type: str('objects'), unit: str('count') }),
+        allocationValueType,
+      ],
+      periodType: allocationValueType,
+      period: 4096,
+      sample: [new Sample({ locationId: [1], value: [1, 100] })],
+      location: [
+        new Location({ id: 1, line: [new Line({ functionId: 1, line: 1 })] }),
+      ],
+      function: [
+        new PprofFunction({
+          id: 1,
+          name: str('foo'),
+          systemName: str('foo'),
+          filename: str(DEP_FILE),
+        }),
+      ],
+      stringTable,
+    });
+
+    processProfile(profile, { stripFilenames: 'all' });
+
+    const resolve = (index: number | bigint): string =>
+      profile.stringTable.strings[Number(index)] as string;
+    assert.equal(resolve(profile.sampleType[1]!.type), 'inuse_space');
+    assert.equal(resolve(profile.periodType!.type), 'inuse_space');
+    assert.equal(resolve(profile.periodType!.unit), 'bytes');
+  });
+
   it('remaps sample type names when rebuilding the string table', () => {
     const profile = processProfile(buildProfile(), { stripFilenames: 'all' });
 


### PR DESCRIPTION
While digging into why a single heap profile from a Node.js service was 429 KiB uncompressed, most of it turned out to be the string table. `processProfile` bakes the absolute file path into every generated function name while the same path is also stored in the pprof `filename` field, and deeply nested `node_modules` paths push many of those strings past 100 bytes. About a quarter of the profile was this duplication alone.

This adds two opt-in config options (also settable via `PYROSCOPE_STRIP_FILENAMES` / `PYROSCOPE_SHORTEN_PATHS`):

- `stripFilenames: 'all' | 'dependencies'` clears `Function.filename` after the display names are generated, then rebuilds the string table so the orphaned path strings are actually dropped from the encoded profile. `'dependencies'` only strips files under `node_modules`, keeping source links for first-party code.
- `shortenPaths: boolean` uses the path relative to the innermost `node_modules` package in generated function names instead of the absolute path, e.g. `/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-stream/dist-cjs/index.js:(anonymous:L#1:C#1):1` becomes `@smithy/util-stream/dist-cjs/index.js:(anonymous:L#1:C#1):1`.

Measured on the same heap profile (1101 samples, 2265 functions, 4729 strings):

| options | raw profile size |
|---|---|
| current | 428,927 B |
| `shortenPaths: true` | 380,782 B (−11.2%) |
| `stripFilenames: 'dependencies'` | 359,335 B (−16.2%) |
| `stripFilenames: 'all'` | 326,263 B (−23.9%) |
| `shortenPaths` + `stripFilenames: 'dependencies'` | 311,179 B (−27.5%) |
| `shortenPaths` + `stripFilenames: 'all'` | 278,107 B (−35.2%) |

Flame graphs are unaffected by `stripFilenames` since the generated names keep the path either way.

Notes:
- Stripping filenames loses the structured filename field that the GitHub integration in Grafana uses to link frames to source code, hence opt-in.
- Docs for the new options need a follow-up.