### PR TITLE
ci: support publishing dev prereleases to npm via workflow dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,32 @@
 name: Release Please
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Publish dev prerelease of {0}', inputs.branch) || '' }}
 
 on:
   push:
     branches:
       - main
+  # Manual dev prereleases live in this workflow (rather than a separate file)
+  # because npm allows a single trusted publisher per package, and it is
+  # pinned to this filename. The branch to publish is an input instead of the
+  # run ref: the "NPM Trusted Publishing" environment only permits runs on
+  # main, and this way the branch does not need to contain this workflow.
+  # Anyone with write access can dispatch this; what stops an unreviewed
+  # publish is the required reviewers on the environment.
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to publish a dev prerelease from'
+        required: true
+        type: string
+      suffix:
+        description: 'Prerelease suffix (defaults to the sanitized branch name)'
+        required: false
+        type: string
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        required: false
+        default: 'dev'
+        type: string
 
 permissions:
   contents: read
@@ -12,6 +35,7 @@ jobs:
   release-please:
     name: Run release-please
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     permissions:
       id-token: write
     outputs:
@@ -65,3 +89,55 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: gh release edit "$TAG_NAME" --draft=false
+
+  publish-dev:
+    name: Publish dev prerelease to npm
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    environment: 'NPM Trusted Publishing'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.branch }}
+          persist-credentials: 'false'
+      - name: Setup .npmrc file to publish to npm
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '26.4.0'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install modules
+        run: yarn
+      - name: Set prerelease version
+        id: version
+        env:
+          BRANCH: ${{ inputs.branch }}
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
+          suffix="${SUFFIX:-$BRANCH}"
+          suffix="$(printf '%s' "$suffix" | tr -c 'A-Za-z0-9-' '-' | sed -E 's/-+/-/g; s/^-+|-+$//g')"
+          version="$(node -p "require('./package.json').version")-${suffix:-dev}.${GITHUB_RUN_NUMBER}"
+          npm version "$version" --no-git-tag-version
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+      - name: Build
+        run: yarn build
+      - name: Publish to npm
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: npm publish --tag "$DIST_TAG"
+      - name: Write summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          {
+            echo "Published \`@pyroscope/nodejs@${VERSION}\` under dist-tag \`${DIST_TAG}\`"
+            echo
+            echo '```'
+            echo "npm install @pyroscope/nodejs@${VERSION}"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,11 +22,6 @@ on:
         description: 'Prerelease suffix (defaults to the sanitized branch name)'
         required: false
         type: string
-      dist_tag:
-        description: 'npm dist-tag to publish under'
-        required: false
-        default: 'dev'
-        type: string
 
 permissions:
   contents: read
@@ -126,16 +121,13 @@ jobs:
       - name: Build
         run: yarn build
       - name: Publish to npm
-        env:
-          DIST_TAG: ${{ inputs.dist_tag }}
-        run: npm publish --tag "$DIST_TAG"
+        run: npm publish --tag dev
       - name: Write summary
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          DIST_TAG: ${{ inputs.dist_tag }}
         run: |
           {
-            echo "Published \`@pyroscope/nodejs@${VERSION}\` under dist-tag \`${DIST_TAG}\`"
+            echo "Published \`@pyroscope/nodejs@${VERSION}\` under dist-tag \`dev\`"
             echo
             echo '```'
             echo "npm install @pyroscope/nodejs@${VERSION}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,3 +7,21 @@ Releases are managed by release-please.
 3. Review and merge the release PR when ready to publish.
 4. The publish workflow creates a draft GitHub release, publishes the package to [NPM](https://www.npmjs.com/package/@pyroscope/nodejs?activeTab=versions) using trusted publishing, then publishes the GitHub release.
 5. If npm publishing fails, the GitHub release remains a draft so the workflow can be retried.
+
+## Dev prereleases
+
+To try out a branch in a real service before its PR merges, publish it as a prerelease:
+
+```
+gh workflow run release-please.yml -f branch=my-feature
+```
+
+or use the "Run workflow" button on the [Release Please workflow](https://github.com/grafana/pyroscope-nodejs/actions/workflows/release-please.yml) (run it from `main` and enter the branch as an input). The run pauses until a maintainer approves it, then publishes `<package.json version>-my-feature.<run number>` under the `dev` dist-tag, so `latest` is never affected. Install it with the exact version printed in the run summary:
+
+```
+npm install @pyroscope/nodejs@0.5.0-my-feature.42
+```
+
+The optional `suffix` input overrides the prerelease suffix (it defaults to the branch name, sanitized to valid semver prerelease characters, e.g. `feat/foo` becomes `feat-foo`).
+
+Repeated publishes of the same branch get a new run number each time, since npm versions are immutable.


### PR DESCRIPTION
Testing a change like #301 in a real service requires an installable package before the PR merges. This adds a manually triggered way to publish a prerelease build of any branch to npm.

npm trusted publishing only allows [one trusted publisher per package](https://docs.npmjs.com/trusted-publishers/), pinned to this repo's `release-please.yml`, so the new publish path is a `workflow_dispatch`-gated job in that same workflow rather than a separate file — no npm settings changes needed. The branch to publish is an input (rather than the ref the workflow is dispatched on) because the `NPM Trusted Publishing` environment only permits runs on `main`; this also means branches created before this workflow landed can be published without a rebase.

Usage:

```
gh workflow run release-please.yml -f branch=my-feature
```

publishes `<package.json version>-my-feature.<run number>` under the `dev` dist-tag, so `latest` is never affected. The `suffix` input overrides the default suffix, which is derived from the branch name (sanitized to valid semver prerelease characters, e.g. `feat/foo` becomes `feat-foo`). The dist-tag is hardcoded to `dev` so a prerelease can never affect `latest`.

Notes:
- Anyone with write access can dispatch workflows; GitHub has no per-workflow ACL. The control that makes this safe is **required reviewers on the `NPM Trusted Publishing` environment** (to be configured by a repo admin alongside this PR): every publish then pauses for approval by a maintainer, who sees the branch in the run name. Without that, this job would effectively grant npm publish capability to anyone with write access, since the published branch's build scripts run inside the trusted job.
- For the same reason, the trusted publisher config on npmjs.com should be verified to pin the environment name — otherwise the environment gate can be sidestepped by a modified workflow.
- Once required reviewers are configured, regular releases keep working as today except the publish job waits for a one-click approval after the release-please PR is merged. If an approval is rejected or expires, recover with "Re-run failed jobs" (a full re-run would skip publishing, since release-please won't report `release_created` again for an existing release).
- The run number makes versions unique across repeated publishes of the same branch, since npm versions are immutable.
