### PR TITLE
fix(ci): skip release PR after release merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,6 +50,8 @@ jobs:
           token: ${{ steps.get-github-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: >-
+            ${{ contains(github.event.head_commit.message, 'chore(main): release ') }}
 
   publish:
     name: Publish npm package


### PR DESCRIPTION
## Summary
- port grafana/pyroscope-python#105 to this repo's release-please workflow
- skip release-please PR creation when the push commit is a release PR merge commit
- keep release creation active for release pushes by only setting `skip-github-pull-request`

## Verification
- git diff --check -- .github/workflows/release-please.yml

Note: actionlint is not installed locally.