### PR TITLE
fix(ci): restore shared workflow updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,4 +27,4 @@ jobs:
           persist-credentials: false
 
       - name: Validate Renovate Config
-        uses: grafana/shared-workflows/actions/validate-renovate-config@46f48da11e78ebdba7a8747ae456b11062fac83e # validate-renovate-config/v0.3.1
+        uses: grafana/shared-workflows/actions/validate-renovate-config@b7474485d59e97b4ee81d5f94f442f072380bf79 # validate-renovate-config/v0.1.4

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "github>grafana/grafana-renovate-config//presets/base",
     "security:only-security-updates"
+  ],
+  "packageRules": [
+    {
+      "description": "Enable Grafana shared workflow updates",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["grafana/shared-workflows"],
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- correct the Renovate validator pin from the nonexistent v0.3.1 annotation to v0.1.4
- allow Renovate to update actions from `grafana/shared-workflows` while keeping other dependencies security-only

## Test plan
- [x] Validate `renovate.json` with `jq`
- [x] Parse the Renovate workflow as YAML
- [ ] Confirm CI passes